### PR TITLE
Support multiple devices in quick example

### DIFF
--- a/universal-login-example/README.md
+++ b/universal-login-example/README.md
@@ -12,8 +12,10 @@ To run example:
 
 ```sh
 cd universal-login-example
-yarn dev:start
+yarn dev:start [hostAddress]
 ```
+
+with `hostAddress` being your machine address where the Universal Login service will be accessible via HTTP (default is `localhost`, only local browser will work).
 
 ### Running example on dev environment (manual option, deprecated, will be removed soon)
 

--- a/universal-login-example/scripts/deployContracts.js
+++ b/universal-login-example/scripts/deployContracts.js
@@ -8,7 +8,7 @@ import Token from '../build/Token';
 const {jsonRpcUrl} = config;
 
 /* eslint-disable no-console */
-class ContractsDelpoyer {
+class ContractsDeployer {
   save(filename, _variables) {
     const variables = Object.entries(_variables)
       .map(([key, value]) => `  ${key}='${value}'`)
@@ -34,5 +34,5 @@ class ContractsDelpoyer {
   }
 }
 
-const prepare = new ContractsDelpoyer();
+const prepare = new ContractsDeployer();
 prepare.main();

--- a/universal-login-example/scripts/dev-start.js
+++ b/universal-login-example/scripts/dev-start.js
@@ -8,6 +8,9 @@ import Token from '../build/Token';
 import {promisify} from 'util';
 import TokenGrantingRelayer from '../src/relayer/TokenGrantingRelayer';
 
+const args = {
+  httpAddress: process.argv.length > 2 ? process.argv[2] : 'localhost'
+};
 
 const chainSpec = {
   ensAddress: process.env.ENS_ADDRESS,
@@ -15,7 +18,7 @@ const chainSpec = {
 };
 
 const config = Object.freeze({
-  jsonRpcUrl: 'http://localhost:18545',
+  jsonRpcUrl: 'http://${args.httpAddress}:18545',
   port: 3311,
   privateKey: defaultAccounts[0].secretKey,
   chainSpec,
@@ -47,7 +50,7 @@ class Deployer {
   }
 
   ganacheUrl() {
-    return `http://localhost:${this.ganachePort}`;
+    return `http://${args.httpAddress}:${this.ganachePort}`;
   }
 
   async startGanache() {
@@ -73,7 +76,7 @@ class Deployer {
     }
     this.env.JSON_RPC_URL = this.ganacheUrl();
     this.config = Object.freeze({
-      jsonRpcUrl: 'http://localhost:18545',
+      jsonRpcUrl: 'http://${args.httpAddress}:18545',
       port: 3311,
       privateKey: defaultAccounts[0].secretKey,
       chainSpec: {
@@ -103,7 +106,7 @@ class Deployer {
 
   startRelayer() {
     this.relayer = new TokenGrantingRelayer({...this.config, privateKey: this.deployerPrivateKey, tokenContractAddress: this.tokenContract.address}, this.provider);    
-    this.env.RELAYER_URL = `http://localhost:${this.config.port}`;
+    this.env.RELAYER_URL = `http://${args.httpAddress}:${this.config.port}`;
     this.relayer.start();
   }
 


### PR DESCRIPTION
This PR solves #132.

I've added an optional command line argument to `dev-start.js` script in order to specify one of the host interfaces as the HTTP address for internal service URLs. I've described the optional parameter in the tutorial.

I've also corrected a typo in `deployContracts.js` script.