### PR TITLE
Invalid ENS name error handling

### DIFF
--- a/universal-login-example/src/components/ContentContainer.js
+++ b/universal-login-example/src/components/ContentContainer.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import Login from './Login';
 import CreatingId from './CreatingId';
 import ApproveConnection from './ApproveConnection';
+import Failure from './Failure';
 import Greeting from './Greeting';
 import Account from './Account';
 import MainScreen from './MainScreen';
@@ -40,6 +41,8 @@ class ContentContainer extends Component {
       return <Login services={services} />;
     } else if (this.state.view === 'CreatingID') {
       return <CreatingId identityService={this.props.services.identityService}/>;
+    } else if (this.state.view === 'Failure') {
+      return <Failure services={services} viewParameters={this.state.viewParameters} />;
     } else if (this.state.view === 'Greeting') {
       return <Greeting
         identityService={services.identityService}
@@ -52,7 +55,7 @@ class ContentContainer extends Component {
     } else if (this.state.view === 'ApproveConnection') {
       return <ApproveConnection services={services}/>;
     } else if (this.state.view === 'PendingAuthorizations') {
-      return <PendingAuthorizations services = {services} setView={this.setView.bind(this)}/>;
+      return <PendingAuthorizations services={services} setView={this.setView.bind(this)}/>;
     } else if (this.state.view === 'Backup') {
       return <Backup services={services} setView={this.setView.bind(this)}/>;
     } else if (this.state.view === 'Trusted') {

--- a/universal-login-example/src/components/Failure.js
+++ b/universal-login-example/src/components/Failure.js
@@ -1,0 +1,27 @@
+import React, {Component} from 'react';
+import FailureView from '../views/FailureView';
+import PropTypes from 'prop-types';
+
+class Failure extends Component {
+  showLogin() {
+    const {emitter} = this.props.services;
+    emitter.emit('setView', 'Login');
+  }
+
+  render() {
+    const {error} = this.props.viewParameters;
+    return (
+      <FailureView
+        errorMessage={error}
+        onBackClick={this.showLogin.bind(this)}
+      />
+    );
+  }
+}
+
+Failure.propTypes = {
+  services: PropTypes.object,
+  viewParameters: PropTypes.object
+};
+
+export default Failure;

--- a/universal-login-example/src/components/Login.js
+++ b/universal-login-example/src/components/Login.js
@@ -45,8 +45,8 @@ class Login extends Component {
       try {
         await this.identityService.createIdentity(identity);
         emitter.emit('setView', 'Greeting', {greetMode: 'created'});
-      } catch (e) {
-        emitter.emit('setView', 'Failure', {error: e.message});
+      } catch (err) {
+        emitter.emit('setView', 'Failure', {error: err.message});
       }
     }
   }

--- a/universal-login-example/src/components/Login.js
+++ b/universal-login-example/src/components/Login.js
@@ -42,8 +42,12 @@ class Login extends Component {
       await this.identityService.connect(label);
     } else {
       emitter.emit('setView', 'CreatingID');
-      await this.identityService.createIdentity(identity);
-      emitter.emit('setView', 'Greeting', {greetMode: 'created'});
+      try {
+        await this.identityService.createIdentity(identity);
+        emitter.emit('setView', 'Greeting', {greetMode: 'created'});
+      } catch (e) {
+        emitter.emit('setView', 'Failure', {error: e.message});
+      }
     }
   }
 

--- a/universal-login-example/src/css/layout/_failure-view.sass
+++ b/universal-login-example/src/css/layout/_failure-view.sass
@@ -1,0 +1,8 @@
+.failure-view
+  padding: 200px 0 100px
+
+  +media(xl)
+    padding: 80px 0 100px
+
+.back-btn
+  margin-top: 50px

--- a/universal-login-example/src/css/main.sass
+++ b/universal-login-example/src/css/main.sass
@@ -25,6 +25,7 @@
 @import layout/base
 @import layout/header
 @import layout/login
+@import layout/failure-view
 @import layout/greeting-view
 @import layout/accounts
 @import layout/main-screen

--- a/universal-login-example/src/views/FailureView.js
+++ b/universal-login-example/src/views/FailureView.js
@@ -1,0 +1,28 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+class FailureView extends Component {
+  render() {
+    const {errorMessage} = this.props;
+    return (
+      <div className="failure-view">
+        <div className="container">
+          <h2>Cannot create your account</h2>
+          <p>
+            {errorMessage}
+          </p>
+          <button className="btn fullwidth back-btn" onClick={this.props.onBackClick.bind(this)}>
+            Back to Login
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+FailureView.propTypes = {
+  errorMessage: PropTypes.string,
+  onBackClick: PropTypes.func
+};
+
+export default FailureView;

--- a/universal-login-relayer/lib/relayer.js
+++ b/universal-login-relayer/lib/relayer.js
@@ -12,10 +12,11 @@ import {EventEmitter} from 'fbemitter';
 
 const defaultPort = 3311;
 
+// eslint-disable-next-line no-unused-vars
 function errorHandler (err, req, res, next) {
   res.status(500)
     .type('json')
-    .send(JSON.stringify({ error: err.toString() }));
+    .send(JSON.stringify({error: err.toString()}));
 }
 
 class Relayer {

--- a/universal-login-relayer/lib/relayer.js
+++ b/universal-login-relayer/lib/relayer.js
@@ -12,6 +12,12 @@ import {EventEmitter} from 'fbemitter';
 
 const defaultPort = 3311;
 
+function errorHandler (err, req, res, next) {
+  res.status(500)
+    .type('json')
+    .send(JSON.stringify({ error: err.toString() }));
+}
+
 class Relayer {
   constructor(config, provider = '') {
     this.port = config.port || defaultPort;
@@ -34,6 +40,7 @@ class Relayer {
     this.app.use('/identity', IdentityRouter(this.identityService));
     this.app.use('/config', ConfigRouter(this.config.chainSpec));
     this.app.use('/authorisation', RequestAuthorisationRouter(this.authorisationService));
+    this.app.use(errorHandler);
     this.server = this.app.listen(this.port);
   }
 

--- a/universal-login-relayer/lib/routes/identity.js
+++ b/universal-login-relayer/lib/routes/identity.js
@@ -13,7 +13,7 @@ export const create = (identityService) => async (req, res, next) => {
   }
 };
 
-export const execution = (identityService) => async (req, res) => {
+export const execution = (identityService) => async (req, res, next) => {
   const {contractAddress, ...message} = req.body;
   try {
     const transaction = await identityService.executeSigned(contractAddress, message);

--- a/universal-login-relayer/lib/routes/identity.js
+++ b/universal-login-relayer/lib/routes/identity.js
@@ -1,20 +1,28 @@
 import express from 'express';
 import asyncMiddleware from '../middlewares/async_middleware';
 
-export const create = (identityService) => async (req, res) => {
+export const create = (identityService) => async (req, res, next) => {
   const {managementKey, ensName} = req.body;
-  const transaction = await identityService.create(managementKey, ensName);
-  res.status(201)
-    .type('json')
-    .send(JSON.stringify({transaction}));
+  try {
+    const transaction = await identityService.create(managementKey, ensName);
+    res.status(201)
+      .type('json')
+      .send(JSON.stringify({transaction}));
+  } catch (err) {
+    next(err);
+  }
 };
 
 export const execution = (identityService) => async (req, res) => {
   const {contractAddress, ...message} = req.body;
-  const transaction = await identityService.executeSigned(contractAddress, message);
-  res.status(201)
-    .type('json')
-    .send(JSON.stringify({transaction}));
+  try {
+    const transaction = await identityService.executeSigned(contractAddress, message);
+    res.status(201)
+      .type('json')
+      .send(JSON.stringify({transaction}));
+  } catch (err) {
+    next(err);
+  }
 };
 
 export default (identityService) => {

--- a/universal-login-relayer/lib/services/IdentityService.js
+++ b/universal-login-relayer/lib/services/IdentityService.js
@@ -19,16 +19,19 @@ class IdentityService {
     const key = addressToBytes32(managementKey);
     const bytecode = `0x${Identity.bytecode}`;
     const ensArgs = this.ensService.argsFor(ensName);
-    const args = [key, ...ensArgs];
-    const deployTransaction = {
-      value: utils.parseEther('0.1'),
-      ...defaultDeployOptions,
-      ...overrideOptions,
-      ...ethers.Contract.getDeployTransaction(bytecode, this.abi, ...args)
-    };
-    const transaction = await this.wallet.sendTransaction(deployTransaction);
-    this.hooks.emit('created', transaction);
-    return transaction;
+    if (ensArgs !== null) {
+      const args = [key, ...ensArgs];
+      const deployTransaction = {
+        value: utils.parseEther('0.1'),
+        ...defaultDeployOptions,
+        ...overrideOptions,
+        ...ethers.Contract.getDeployTransaction(bytecode, this.abi, ...args)
+      };
+      const transaction = await this.wallet.sendTransaction(deployTransaction);
+      this.hooks.emit('created', transaction);
+      return transaction;
+    }
+    throw new Error('domain not existing / not universal ID compatible');
   }
 
   async executeSigned(contractAddress, message) {

--- a/universal-login-relayer/lib/services/ensService.js
+++ b/universal-login-relayer/lib/services/ensService.js
@@ -8,7 +8,7 @@ class ENSService {
 
   findRegistrar(ensName) {
     const [, domain] = this.get2ndLevelDomainForm(ensName);
-    return this.ensRegistrars[domain];
+    return this.ensRegistrars[domain] || null;
   }
 
   get2ndLevelDomainForm(ensName) {
@@ -24,6 +24,7 @@ class ENSService {
     const hashLabel = utils.keccak256(utils.toUtf8Bytes(label));
     const node = utils.namehash(`${label}.${domain}`);
     const registrarConfig = this.findRegistrar(ensName);
+    if (registrarConfig === null) return null;
     const {resolverAddress} = registrarConfig;
     const {registrarAddress} = registrarConfig;
     return [hashLabel, ensName, node, this.ensAddress, registrarAddress, resolverAddress];

--- a/universal-login-relayer/lib/services/ensService.js
+++ b/universal-login-relayer/lib/services/ensService.js
@@ -24,7 +24,9 @@ class ENSService {
     const hashLabel = utils.keccak256(utils.toUtf8Bytes(label));
     const node = utils.namehash(`${label}.${domain}`);
     const registrarConfig = this.findRegistrar(ensName);
-    if (registrarConfig === null) return null;
+    if (registrarConfig === null) {
+      return null;
+    }
     const {resolverAddress} = registrarConfig;
     const {registrarAddress} = registrarConfig;
     return [hashLabel, ensName, node, this.ensAddress, registrarAddress, resolverAddress];

--- a/universal-login-relayer/test/relayer/services/IdentityService.js
+++ b/universal-login-relayer/test/relayer/services/IdentityService.js
@@ -68,6 +68,10 @@ describe('Relayer - IdentityService', async () => {
         await identityService.executeSigned(contract.address, {...msg, signature});
         expect(await provider.getBalance(msg.to)).to.eq(expectedBalance);
       });
+
+      it('should fail with not existing ENS name', async () => {
+        expect(identityService.create(managementKey.address, 'alex.non-existing-id.eth')).to.be.eventually.rejectedWith('domain not existing / not universal ID compatible');
+      });
     });
 
     describe('Add Key', async () => {

--- a/universal-login-relayer/test/relayer/services/IdentityService.js
+++ b/universal-login-relayer/test/relayer/services/IdentityService.js
@@ -53,6 +53,12 @@ describe('Relayer - IdentityService', async () => {
     it('should emit created event', async () => {
       expect(callback).to.be.calledWith(sinon.match(transaction));
     });
+
+    it('should fail with not existing ENS name', async () => {
+      const managementKeys = await contract.getKeysByPurpose(MANAGEMENT_KEY);
+      expect(managementKeys).to.have.lengthOf(1);
+      await expect(identityService.create(managementKeys[0], 'alex.non-existing-id.eth')).to.be.eventually.rejectedWith('domain not existing / not universal ID compatible');
+    });
   });
 
   describe('Execute signed', async () => {
@@ -67,10 +73,6 @@ describe('Relayer - IdentityService', async () => {
         const signature = calculateMessageSignature(wallet, msg);
         await identityService.executeSigned(contract.address, {...msg, signature});
         expect(await provider.getBalance(msg.to)).to.eq(expectedBalance);
-      });
-
-      it('should fail with not existing ENS name', async () => {
-        expect(identityService.create(managementKey.address, 'alex.non-existing-id.eth')).to.be.eventually.rejectedWith('domain not existing / not universal ID compatible');
       });
     });
 

--- a/universal-login-relayer/test/relayer/services/ensService.js
+++ b/universal-login-relayer/test/relayer/services/ensService.js
@@ -13,6 +13,11 @@ describe('Relayer - ENSService', async () => {
         registrarAddress: '0x1',
         resolverAddress: '0x2',
         privateKey: '0x3'
+      },
+      'universal-id.eth': {
+        registrarAddress: '0x1',
+        resolverAddress: '0x2',
+        privateKey: '0x3'
       }
     };
     ensService = new ENSService('0x4', ensRegistrars);
@@ -48,8 +53,14 @@ describe('Relayer - ENSService', async () => {
       expect(ensService.findRegistrar('universal-id.eth')).to.deep.eq(ensRegistrars['universal-id.eth']);
     });
 
-    it('return undefined if not found', async () => {
-      expect(ensService.findRegistrar('whatever.non-existing-id.eth')).to.be.undefined;
+    it('return null if not found', async () => {
+      expect(ensService.findRegistrar('whatever.non-existing-id.eth')).to.be.null;
+    });
+  });
+
+  describe('argsFor', () => {
+    it('return null if not found', async () => {
+      expect(ensService.argsFor('whatever.non-existing-id.eth')).to.be.null;
     });
   });
 });

--- a/universal-login-sdk/lib/sdk.js
+++ b/universal-login-sdk/lib/sdk.js
@@ -30,7 +30,7 @@ class EthereumIdentitySDK {
       const contract = await waitForContractDeploy(this.provider, Identity, responseJson.transaction.hash);
       return [privateKey, contract.address];
     }
-    throw new Error(`${response.status}`);
+    throw new Error(`${responseJson.error}`);
   }
 
   async addKey(to, publicKey, privateKey, transactionDetails) {

--- a/universal-login-sdk/test/sdk.js
+++ b/universal-login-sdk/test/sdk.js
@@ -69,7 +69,9 @@ describe('SDK - integration', async () => {
         expect(response.config.ensAddress).to.eq(expectedEnsAddress);
       });
 
-      xit('should throw InvalidENS exception if invalid ENS name');
+      it('should throw InvalidENS exception if invalid ENS name', async () => {
+        await expect(sdk.create('alex.non-existing-id.eth')).to.be.eventually.rejectedWith('Error: domain not existing / not universal ID compatible');
+      });
     });
 
     describe('Execute signed message', async () => {
@@ -102,7 +104,7 @@ describe('SDK - integration', async () => {
           gasPrice,
           gasLimit: utils.parseEther('25').toString() 
         };
-        expect(sdk.execute(identityAddress, message, privateKey)).to.be.eventually.rejected;
+        await expect(sdk.execute(identityAddress, message, privateKey)).to.be.eventually.rejected;
       });
     });
 


### PR DESCRIPTION
This PR addresses #99 

I've made the following working assumptions:
- client side: a simple dedicated Failure view is provided (purely additive)
- server side: the application errors are strings
- server side: the same error handling mechanism also for executeSigned API
- server side: one generic HTTP status 500 is fine for reporting errors

Possible improvements:
- using error codes shared between server and client instead of error strings (for i18n)
- using specific exception instead of generic Error (for additional info, not sure about advantages here)