### PR TITLE
remove eventstream and flatmap-stream dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,19 +3447,6 @@ ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-event-stream@^3.3.4:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz#cac1230890e07e73ec9cacd038f60a5b66173eef"
-  dependencies:
-    duplexer "^0.1.1"
-    flatmap-stream "^0.1.0"
-    from "^0.1.7"
-    map-stream "0.0.7"
-    pause-stream "^0.0.11"
-    split "^1.0.1"
-    stream-combiner "^0.2.2"
-    through "^2.3.8"
-
 eventemitter3@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.1.1.tgz#47786bdaa087caf7b1b75e73abc5c7d540158cd0"


### PR DESCRIPTION
These references are not at all required and just cause the project build to fail. None of the packages depend on this code.

The flatmap package was pulled from NPM due to being backdoored (https://github.com/dominictarr/event-stream/issues/115)

Closes #151 
