### PR TITLE
addKey can also be used to add to the identity all of the avaible types of keys

### DIFF
--- a/universal-login-sdk/lib/sdk.js
+++ b/universal-login-sdk/lib/sdk.js
@@ -34,9 +34,9 @@ class EthereumIdentitySDK {
     throw new Error(`${responseJson.error}`);
   }
 
-  async addKey(to, publicKey, privateKey, transactionDetails) {
+  async addKey(to, publicKey, privateKey, transactionDetails, keyPurpose = MANAGEMENT_KEY) {
     const key = addressToBytes32(publicKey);
-    const data = new utils.Interface(Identity.interface).functions.addKey.encode([key, MANAGEMENT_KEY, ECDSA_TYPE]);
+    const data = new utils.Interface(Identity.interface).functions.addKey.encode([key, keyPurpose, ECDSA_TYPE]);
     const message = {
       ...transactionDetails,
       to,
@@ -46,11 +46,11 @@ class EthereumIdentitySDK {
     return await this.execute(message, privateKey);
   }
 
-  async addKeys(to, publicKeys, privateKey, transactionDetails) {
+  async addKeys(to, publicKeys, privateKey, transactionDetails, keyPurpose = MANAGEMENT_KEY) {
     const keys = publicKeys.map((publicKey) => addressToBytes32(publicKey));
-    const keyRoles = new Array(publicKeys.length).fill(MANAGEMENT_KEY);
-    const keyTypes = new Array(publicKeys.length).fill(ECDSA_TYPE);
-    const data = new utils.Interface(Identity.interface).functions.addKeys.encode([keys, keyRoles, keyTypes]);
+    const keyRoles = new Array(publicKeys.length).fill(keyPurpose);
+    const keyPurposes = new Array(publicKeys.length).fill(ECDSA_TYPE);
+    const data = new utils.Interface(Identity.interface).functions.addKeys.encode([keys, keyRoles, keyPurposes]);
     const message = {
       ...transactionDetails,
       to,

--- a/universal-login-sdk/test/fixtures/basicSDK.js
+++ b/universal-login-sdk/test/fixtures/basicSDK.js
@@ -1,8 +1,9 @@
 import EthereumIdentitySDK from '../../lib/sdk';
 import {RelayerUnderTest} from 'universal-login-relayer';
 import {getWallets, deployContract} from 'ethereum-waffle';
-import {utils} from 'ethers';
+import {utils, ContractFactory} from 'ethers';
 import path from 'path';
+import Identity from 'universal-login-contracts/build/Identity';
 import MockToken from 'universal-login-contracts/build/MockToken';
 import MESSAGE_DEFAULTS from '../../lib/config';
 import {getKnexConfig} from 'universal-login-relayer/lib/utils/knexUtils';
@@ -21,7 +22,9 @@ export default async function basicIdentityService(wallet) {
   const mockToken = await deployContract(wallet, MockToken);
   await mockToken.transfer(contractAddress, utils.parseEther('1.0'));
   await wallet.sendTransaction({to: contractAddress, value: utils.parseEther('1.0')});
-  return {wallet, provider, mockToken, otherWallet, otherWallet2, sdk, privateKey, contractAddress, relayer};
+  const factory = new ContractFactory(Identity.abi, Identity.bytecode, wallet);
+  const identity = await factory.attach(contractAddress);
+  return {wallet, provider, mockToken, otherWallet, otherWallet2, sdk, privateKey, contractAddress, identity, relayer};
 }
 
 export const transferMessage = {


### PR DESCRIPTION
While studying the functioning of action keys and management keys i noticed that sdk.addKey and sdk.addKeys, can only be used to add management keys to the identity, therefore to study action keys i modified sdk.js so that addKey now needs a new argument(keyType) that is the type of the new key( Management, Action, Encryption) which is set by default to MANAGEMENT_KEY. modifying that variable we can choose if we wants to add a Management, Action or Encryption key. i decided to create this pr just because i thought it might be useful.