### PR TITLE
KeyHolder now keeps track on how many keys are in the contract

### DIFF
--- a/universal-login-contracts/contracts/KeyHolder.sol
+++ b/universal-login-contracts/contracts/KeyHolder.sol
@@ -5,10 +5,12 @@ import "./IKeyHolder.sol";
 contract KeyHolder is IKeyHolder {
     mapping (address => Key) public keys;
 
+    uint _keyCount;
+
     constructor(address _key) public {
         keys[_key].key = _key;
         keys[_key].purpose = MANAGEMENT_KEY;
-
+        _keyCount = 1;
         emit KeyAdded(keys[_key].key,  keys[_key].purpose);
     }
 
@@ -29,6 +31,10 @@ contract KeyHolder is IKeyHolder {
         _;
     }
 
+    function keyCount() public view returns(uint) {
+        return _keyCount;
+    }
+
     function keyExist(address _key) public view returns(bool) {
         return keys[_key].key != address(0x0);
     }
@@ -46,7 +52,7 @@ contract KeyHolder is IKeyHolder {
 
         keys[_key].key = _key;
         keys[_key].purpose = _purpose;
-
+        _keyCount += 1;
         emit KeyAdded(keys[_key].key,  keys[_key].purpose);
 
         return true;
@@ -67,6 +73,7 @@ contract KeyHolder is IKeyHolder {
         emit KeyRemoved(keys[_key].key, keys[_key].purpose);
 
         delete keys[_key];
+        _keyCount -= 1;
 
         return true;
     }

--- a/universal-login-contracts/contracts/KeyHolder.sol
+++ b/universal-login-contracts/contracts/KeyHolder.sol
@@ -5,12 +5,12 @@ import "./IKeyHolder.sol";
 contract KeyHolder is IKeyHolder {
     mapping (address => Key) public keys;
 
-    uint _keyCount;
+    uint public keyCount;
 
     constructor(address _key) public {
         keys[_key].key = _key;
         keys[_key].purpose = MANAGEMENT_KEY;
-        _keyCount = 1;
+        keyCount = 1;
         emit KeyAdded(keys[_key].key,  keys[_key].purpose);
     }
 
@@ -31,10 +31,6 @@ contract KeyHolder is IKeyHolder {
         _;
     }
 
-    function keyCount() public view returns(uint) {
-        return _keyCount;
-    }
-
     function keyExist(address _key) public view returns(bool) {
         return keys[_key].key != address(0x0);
     }
@@ -52,7 +48,7 @@ contract KeyHolder is IKeyHolder {
 
         keys[_key].key = _key;
         keys[_key].purpose = _purpose;
-        _keyCount += 1;
+        keyCount += 1;
         emit KeyAdded(keys[_key].key,  keys[_key].purpose);
 
         return true;
@@ -73,7 +69,7 @@ contract KeyHolder is IKeyHolder {
         emit KeyRemoved(keys[_key].key, keys[_key].purpose);
 
         delete keys[_key];
-        _keyCount -= 1;
+        keyCount -= 1;
 
         return true;
     }

--- a/universal-login-contracts/test/contracts/KeyHolder.js
+++ b/universal-login-contracts/test/contracts/KeyHolder.js
@@ -35,6 +35,10 @@ describe('KeyHolder', async () => {
       expect(await identity.getKeyPurpose(managementKey)).to.eq(MANAGEMENT_KEY);
     });
 
+    it('there must be a total of 3 keys', async () => {
+      expect(await identity.keyCount()).to.eq(3);
+    });
+
     it('Should return the purpose', async () => {
       expect(await identity.keyHasPurpose(managementKey, MANAGEMENT_KEY)).to.be.true;
       expect(await identity.keyHasPurpose(managementKey, ACTION_KEY)).to.be.false;
@@ -50,6 +54,7 @@ describe('KeyHolder', async () => {
       const existingKeys = await identity.keys(actionKey);
       expect(existingKeys[0]).to.eq(ACTION_KEY);
       expect(existingKeys[1]).to.eq(utils.hexlify(actionKey));
+      expect(await identity.keyCount()).to.eq(4);
     });
 
     it('Should not allow to add existing key', async () => {
@@ -82,6 +87,7 @@ describe('KeyHolder', async () => {
       const existingKeys2 = await identity.keys(actionKey2);
       expect(existingKeys2[0]).to.eq(ACTION_KEY);
       expect(existingKeys2[1]).to.eq(utils.hexlify(actionKey2));
+      expect(await identity.keyCount()).to.eq(5);
     });
 
     it('Should not allow to add existing key', async () => {
@@ -114,12 +120,14 @@ describe('KeyHolder', async () => {
   describe('Remove key', async () => {
     beforeEach(async () => {
       await addActionKey();
+      expect(await identity.keyCount()).to.eq(4);
     });
 
     it('Should remove key successfully', async () => {
       expect(await isActionKey()).to.be.true;
       await identity.removeKey(actionKey, ACTION_KEY);
       expect(await identity.keyHasPurpose(actionKey, ACTION_KEY)).to.be.false;
+      expect(await identity.keyCount()).to.eq(3);
     });
 
     it('Should emit KeyRemoved event successfully', async () => {


### PR DESCRIPTION
# Summary
In order for the identity to require a certain signatures number in the identity/wallet we need to avoid the user to put a number of required that exceed the actual number of keys present in the keyHolders, to do so we need a variable that increase and decrease along with addition or deletion of keys. i would like to split the addition of a required amount of signatures in the identity in small Pull requests, that's why this Pull Request is very small.

## Checklist
- [X] Change is small and easy to review (please split big changes into multiple PRs)
- [X] Change is consistent with architecture
- [X] Change is consistent with test architecture
- [X] Change is consistent with naming conventions
- [X] New code is covered with tests
- [x] Tests related to old code are updated
- [ ] Documentation is up to date with changes

