### PR TITLE
Support for nested ENS domain

### DIFF
--- a/universal-login-relayer/lib/services/ensService.js
+++ b/universal-login-relayer/lib/services/ensService.js
@@ -23,16 +23,8 @@ class ENSService {
     return this.domainsInfo[domain] || null;
   }
 
-  get2ndLevelDomainForm(ensName) {
-    const labels = ensName.split('.');
-    const {length} = labels;
-    const label = labels.slice(0, length - 2).join('.');
-    const domain = labels.slice(length - 2, length).join('.');
-    return [label, domain];
-  }
-
   argsFor(ensName) {
-    const [label, domain] = this.get2ndLevelDomainForm(ensName);
+    const [label, domain] = ensName.split(/\.(.*)/);
     const hashLabel = utils.keccak256(utils.toUtf8Bytes(label));
     const node = utils.namehash(`${label}.${domain}`);
     const registrarConfig = this.findRegistrar(domain);

--- a/universal-login-relayer/lib/utils/ensDeployer.js
+++ b/universal-login-relayer/lib/utils/ensDeployer.js
@@ -33,7 +33,7 @@ class ENSDeployer {
     await builder.registerReverseRegistrar();
     for (let count = 0; count < registrars.length; count++) {
       const domain = registrars[count];
-      const [label, tld] = domain.split('.');
+      const [label, tld] = domain.split(/\.(.*)/);
       await builder.registerDomain(label, tld);
       this.count += 1;
     }

--- a/universal-login-relayer/lib/utils/relayerUnderTest.js
+++ b/universal-login-relayer/lib/utils/relayerUnderTest.js
@@ -14,7 +14,7 @@ class RelayerUnderTest extends Relayer {
     const privateKey = defaultAccounts.slice(-1)[0].secretKey;
     const defaultDomain = 'mylogin.eth';
     const ensBuilder = new ENSBuilder(deployerWallet);
-    const [label, tld] = defaultDomain.split('.');
+    const [label, tld] = defaultDomain.split(/\.(.*)/);
     const ensAddress = await ensBuilder.bootstrapWith(label, tld);
     const providerWithENS = withENS(provider, ensAddress);
     const config = {


### PR DESCRIPTION
Current splitting method assumes `label.domain.eth` structure to extract label and domain. This only work because ethers.js autocompletes domain to domain.eth. It will not work with other tld's and with subdomain.

To support `user.subdomain.domain.xyz`, the splitting should be done at the first `.` only, so that `label = user` and `node=subdomain.domain.xyz`. This is what this PR implements