### PR TITLE
CircleCI improvement, KeyHolder revert

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,11 +107,10 @@ jobs:
             keys:
                 - universal-login-{{ .Environment.CIRCLE_SHA1 }}
       - run: cd universal-login-wallet && yarn test
-  run_klab:
+
+  build_klab:
     docker:
       - image: circleci/node:10.15
-        environment:
-          TERM: xterm-256color
     steps:
       - checkout
       - run: sudo apt-get install make gcc maven openjdk-8-jdk flex pkg-config libmpfr-dev autoconf libtool pandoc zlib1g-dev z3 libz3-dev
@@ -119,17 +118,35 @@ jobs:
       - run: |
           cd klab
           make deps
+      - save_cache:
+            key: night-klab-build-{{ epoch }}
+            paths:
+              - ~/project
+
+  run_klab:
+    docker:
+      - image: circleci/node:10.15
+        environment:
+          TERM: xterm-256color
+    steps:
+      - restore_cache:
+          keys:
+            - night-klab-build
       - run: |
           cd klab
           sudo make link
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: |
-          export PATH=$PATH:/usr/local/bin
-          export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
-          export TMPDIR=/tmp
-          cd universal-login-formal-verification
-          make proof
+      - run: | 
+          sudo apt-get install openjdk-8-jdk flex z3 libz3-dev
+      - run:
+          command: |
+            export PATH=$PATH:/usr/local/bin
+            export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
+            export TMPDIR=/tmp
+            cd universal-login-formal-verification
+            make proof
+          no_output_timeout: 50m
 
   run_klab_1:
     docker:
@@ -137,23 +154,24 @@ jobs:
         environment:
           TERM: xterm-256color
     steps:
-      - checkout
-      - run: sudo apt-get install make gcc maven openjdk-8-jdk flex pkg-config libmpfr-dev autoconf libtool pandoc zlib1g-dev z3 libz3-dev
-      - run: git clone https://github.com/dapphub/klab.git
-      - run: |
-          cd klab
-          make deps
+      - restore_cache:
+          keys:
+            - night-klab-build
       - run: |
           cd klab
           sudo make link
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: |
-          export PATH=$PATH:/usr/local/bin
-          export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
-          export TMPDIR=/tmp
-          cd universal-login-formal-verification
-          make proof-1
+      - run: | 
+          sudo apt-get install openjdk-8-jdk flex z3 libz3-dev
+      - run:
+          command: |
+            export PATH=$PATH:/usr/local/bin
+            export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
+            export TMPDIR=/tmp
+            cd universal-login-formal-verification
+            make proof-1
+          no_output_timeout: 50m
 
   run_klab_2:
     docker:
@@ -161,23 +179,24 @@ jobs:
         environment:
           TERM: xterm-256color
     steps:
-      - checkout
-      - run: sudo apt-get install make gcc maven openjdk-8-jdk flex pkg-config libmpfr-dev autoconf libtool pandoc zlib1g-dev z3 libz3-dev
-      - run: git clone https://github.com/dapphub/klab.git
-      - run: |
-          cd klab
-          make deps
+      - restore_cache:
+          keys:
+            - night-klab-build
       - run: |
           cd klab
           sudo make link
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: |
-          export PATH=$PATH:/usr/local/bin
-          export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
-          export TMPDIR=/tmp
-          cd universal-login-formal-verification
-          make proof-2
+      - run: | 
+          sudo apt-get install openjdk-8-jdk flex z3 libz3-dev
+      - run:
+          command: |
+            export PATH=$PATH:/usr/local/bin
+            export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
+            export TMPDIR=/tmp
+            cd universal-login-formal-verification
+            make proof-2
+          no_output_timeout: 50m
 
   run_klab_3:
     docker:
@@ -185,23 +204,24 @@ jobs:
         environment:
           TERM: xterm-256color
     steps:
-      - checkout
-      - run: sudo apt-get install make gcc maven openjdk-8-jdk flex pkg-config libmpfr-dev autoconf libtool pandoc zlib1g-dev z3 libz3-dev
-      - run: git clone https://github.com/dapphub/klab.git
-      - run: |
-          cd klab
-          make deps
+      - restore_cache:
+          keys:
+            - night-klab-build
       - run: |
           cd klab
           sudo make link
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: |
-          export PATH=$PATH:/usr/local/bin
-          export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
-          export TMPDIR=/tmp
-          cd universal-login-formal-verification
-          make proof-3
+      - run: | 
+          sudo apt-get install openjdk-8-jdk flex z3 libz3-dev
+      - run:
+          command: |
+            export PATH=$PATH:/usr/local/bin
+            export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
+            export TMPDIR=/tmp
+            cd universal-login-formal-verification
+            make proof-3
+          no_output_timeout: 50m
 
   run_klab_4:
     docker:
@@ -209,26 +229,28 @@ jobs:
         environment:
           TERM: xterm-256color
     steps:
-      - checkout
-      - run: sudo apt-get install make gcc maven openjdk-8-jdk flex pkg-config libmpfr-dev autoconf libtool pandoc zlib1g-dev z3 libz3-dev
-      - run: git clone https://github.com/dapphub/klab.git
-      - run: |
-          cd klab
-          make deps
+      - restore_cache:
+          keys:
+            - night-klab-build
       - run: |
           cd klab
           sudo make link
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: |
-          export PATH=$PATH:/usr/local/bin
-          export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
-          export TMPDIR=/tmp
-          cd universal-login-formal-verification
-          make proof-4
+      - run: | 
+          sudo apt-get install openjdk-8-jdk flex z3 libz3-dev
+      - run:
+          command: |
+            export PATH=$PATH:/usr/local/bin
+            export KLAB_EVMS_PATH=/home/circleci/project/klab/evm-semantics
+            export TMPDIR=/tmp
+            cd universal-login-formal-verification
+            make proof-4
+          no_output_timeout: 50m
 
 workflows:
   version: 2
+
   nightly_formal_verification:
     triggers:
       - schedule:
@@ -238,26 +260,38 @@ workflows:
               only:
                 - master
     jobs:
-      - run_klab
-  fv_test:
+      - build_klab
+      - run_klab:
+          requires:
+            - build_klab
+
+  fv_test_distributed:
     jobs:
       - run_klab_1:
           filters:
             branches:
-              only:
-                - /fv.*/
+              only: /fv-dist.*/
       - run_klab_2:
           filters:
             branches:
-              only: /fv.*/
+              only: /fv-dist.*/
       - run_klab_3:
           filters:
             branches:
-              only: /fv.*/
+              only: /fv-dist.*/
       - run_klab_4:
           filters:
             branches:
-              only: /fv.*/
+              only: /fv-dist.*/
+
+  fv_test_one_job:
+    jobs:
+      - run_klab:
+          filters:
+            branches:
+              only:
+                - /fv-one.*/
+
   universal_login_all:
     jobs:
       - build

--- a/universal-login-contracts/contracts/KeyHolder/KeyHolder.sol
+++ b/universal-login-contracts/contracts/KeyHolder/KeyHolder.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.5.2;
+
 import "./IKeyHolder.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 contract KeyHolder is IKeyHolder {
-    using SafeMath for uint;
 
     uint constant MAX_KEYS_PER_ADD = 5;
 
@@ -48,11 +47,10 @@ contract KeyHolder is IKeyHolder {
     }
 
     function addKey(address _key, uint256 _purpose) public onlyManagementKeyOrThisContract returns(bool success) {
-        require(_key != msg.sender);
         require(keys[_key].key != _key, "Key already added");
         keys[_key].key = _key;
         keys[_key].purpose = _purpose;
-        keyCount = keyCount.add(1);
+        keyCount = keyCount + 1;
         emit KeyAdded(keys[_key].key,  keys[_key].purpose);
 
         return true;
@@ -70,13 +68,12 @@ contract KeyHolder is IKeyHolder {
     }
 
     function removeKey(address _key, uint256 _purpose) public  onlyManagementKeyOrThisContract returns(bool success) {
-        require(_key != msg.sender); //Simplifies formal verification
         require(keys[_key].purpose == _purpose, "Invalid key");
 
         emit KeyRemoved(keys[_key].key, keys[_key].purpose);
 
         delete keys[_key];
-        keyCount = keyCount.sub(1);
+        keyCount = keyCount - 1;
 
         return true;
     }

--- a/universal-login-formal-verification/Makefile
+++ b/universal-login-formal-verification/Makefile
@@ -5,54 +5,36 @@ SRC_JSON = dapp/out/KeyHolder.sol.json
 SOLC = ethereum/solc:0.5.2
 
 SRC_SOL:= ../universal-login-contracts/contracts/KeyHolder/KeyHolder.sol \
-		  ../universal-login-contracts/contracts/KeyHolder/IKeyHolder.sol
+		  ../universal-login-contracts/contracts/KeyHolder/IKeyHolder.sol 
+
+INVOKE_TESTS := do \
+					klab prove $$f > out.txt; \
+					cat out.txt; \
+					cat out.txt | grep "ACCEPT"; \
+					if [ $$? -ne 0 ]; then exit 1; fi; \
+				done;
 
 MAIN_SOL = KeyHolder.sol
 
 proof: build
 	for f in out/specs/*; \
-	do \
-		klab prove $$f > out.txt; \
-		cat out.txt; \
-		cat out.txt | grep "ACCEPT"; \
-		if [ $$? -ne 0 ]; then exit 1; fi; \
-	done;
+	$(INVOKE_TESTS)
 
 proof-1: build
 	for f in out/specs/KeyHolder_addKey*; \
-	do \
-		klab prove $$f > out.txt; \
-		cat out.txt; \
-		cat out.txt | grep "ACCEPT"; \
-		if [ $$? -ne 0 ]; then exit 1; fi; \
-	done;
+	$(INVOKE_TESTS)
 
 proof-2: build
 	for f in out/specs/KeyHolder_removeKey*; \
-	do \
-		klab prove $$f > out.txt; \
-		cat out.txt; \
-		cat out.txt | grep "ACCEPT"; \
-		if [ $$? -ne 0 ]; then exit 1; fi; \
-	done;
+	$(INVOKE_TESTS)
 
 proof-3: build
 	for f in out/specs/KeyHolder_key*; \
-	do \
-		klab prove $$f > out.txt; \
-		cat out.txt; \
-		cat out.txt | grep "ACCEPT"; \
-		if [ $$? -ne 0 ]; then exit 1; fi; \
-	done;
+	$(INVOKE_TESTS)
 
 proof-4: build
 	for f in out/specs/KeyHolder_get*; \
-	do \
-		klab prove $$f > out.txt; \
-		cat out.txt; \
-		cat out.txt | grep "ACCEPT"; \
-		if [ $$? -ne 0 ]; then exit 1; fi; \
-	done;
+	$(INVOKE_TESTS)
 
 build: $(SRC_JSON) $(SRC_SPEC)
 	klab build


### PR DESCRIPTION
CircleCI:
* added nightly klab_build to make daily tests faster (nightly built KLAB is cached);
* added possibility to invoke (daily on demand) both distributed (4 jobs) and full one job test suite;
* "no output" limit increased for a single job (some tests were stopped because of time limit exceeds)

Makefile:
* simplifying refactoring

KeyHolder (contract and spec): back to working version (before SafeMath added)

## Checklist
- [ ] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [ ] Documentation is up to date with changes

