### PR TITLE
Remove mock token from observed tokens

### DIFF
--- a/universal-login-wallet/src/config/config.ts
+++ b/universal-login-wallet/src/config/config.ts
@@ -8,7 +8,7 @@ export default Object.freeze({
     domains: ['mylogin.eth'],
     relayerUrl: 'http://localhost:3311',
     jsonRpcUrl: 'http://localhost:18545',
-    tokens: [process.env.TOKEN_CONTRACT_ADDRESS!, ETHER_NATIVE_TOKEN.address],
+    tokens: [ETHER_NATIVE_TOKEN.address],
   },
 
   test: {


### PR DESCRIPTION
Setup: `universal-login-wallet`, `developer-mode`

Experiencing `mock token contract not deployed` kind of error after recent change in https://github.com/UniversalLogin/UniversalLoginSDK/blob/master/universal-login-ops/src/dev/startDevelopment.ts
