### PR TITLE
Fix ropsten wallet link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Packages maintained with this monorepo are listed below.
 ### Ropsten:
 - Domains: `poppularapp.test`, `my-login.test`, `universal-login.test`
 - Relayer url: `universal-login-relayer.herokuapp.com`
-- Jarvis Wallet (web wallet): [wallet.universallogin.io](wallet.universallogin.io)
+- Jarvis Wallet (web wallet): [wallet.universallogin.io](https://wallet.universallogin.io)
 
 ## Contributing
 


### PR DESCRIPTION
# Summary
Fixes the newly added link to the Ropsten testnet Jarvis wallet instance in README.md.
(Currently goes to https://github.com/UniversalLogin/UniversalLoginSDK/blob/master/wallet.universallogin.io)

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)

