### PR TITLE
[WIP] Relayer: Refactoring validations - introducing ethereum validators

### DIFF
--- a/universal-login-relayer/lib/integration/ethereum/validators/CorrectProxyValidator.ts
+++ b/universal-login-relayer/lib/integration/ethereum/validators/CorrectProxyValidator.ts
@@ -1,0 +1,19 @@
+import {Wallet, utils} from 'ethers';
+import {ContractWhiteList, SignedMessage, ensure} from '@universal-login/commons';
+import IMessageValidator from '../../../core/services/validators/IMessageValidator';
+import {InvalidProxy} from '../../../core/utils/errors';
+
+export default class CorrectProxyValidator implements IMessageValidator {
+  constructor(private wallet: Wallet, private contractWhiteList: ContractWhiteList) {}
+
+  async validate(signedMessage: SignedMessage) {
+    const proxyByteCode = await this.wallet.provider.getCode(signedMessage.from);
+    const proxyContractHash = utils.keccak256(proxyByteCode);
+    ensure(
+      this.contractWhiteList.proxy.includes(proxyContractHash),
+      InvalidProxy,
+      signedMessage.from,
+      proxyContractHash,
+      this.contractWhiteList.proxy);
+  }
+}

--- a/universal-login-relayer/lib/integration/ethereum/validators/EnoughGasValidator.ts
+++ b/universal-login-relayer/lib/integration/ethereum/validators/EnoughGasValidator.ts
@@ -1,0 +1,15 @@
+import {Wallet, providers, utils} from 'ethers';
+import {SignedMessage, ensure} from '@universal-login/commons';
+import IMessageValidator from '../../../core/services/validators/IMessageValidator';
+import {messageToTransaction} from '../../../core/utils/utils';
+import {NotEnoughGas} from '../../../core/utils/errors';
+
+export default class EnoughGasValidator implements IMessageValidator {
+  constructor(private wallet: Wallet) {}
+
+  async validate(signedMessage: SignedMessage) {
+    const transactionReq: providers.TransactionRequest = messageToTransaction(signedMessage);
+    const estimateGas = await this.wallet.provider.estimateGas({ ...transactionReq, from: this.wallet.address });
+    ensure(utils.bigNumberify(signedMessage.gasLimitExecution as utils.BigNumberish).gte(estimateGas), NotEnoughGas); // TODO Add gasData to gasLimitExecution !!!!
+  }
+}

--- a/universal-login-relayer/lib/integration/ethereum/validators/EnoughTokenValidator.ts
+++ b/universal-login-relayer/lib/integration/ethereum/validators/EnoughTokenValidator.ts
@@ -1,0 +1,33 @@
+import ERC20 from '@universal-login/contracts/build/ERC20.json';
+import {Wallet, providers, utils, Contract} from 'ethers';
+import {SignedMessage, ETHER_NATIVE_TOKEN, ensure, isContractExist} from '@universal-login/commons';
+import IMessageValidator from '../../../core/services/validators/IMessageValidator';
+import {NotEnoughTokens, InvalidContract} from '../../../core/utils/errors';
+
+const isContract = async (provider : providers.Provider, contractAddress : string) => {
+  // TODO: Only whitelisted contracts
+  const bytecode = await provider.getCode(contractAddress);
+  return isContractExist(bytecode);
+};
+
+const hasEnoughToken = async (gasToken : string, walletContractAddress : string, gasLimit : utils.BigNumberish, provider : providers.Provider) => {
+  // TODO: Only whitelisted tokens/contracts
+  if (gasToken === ETHER_NATIVE_TOKEN.address) {
+    const walletBalance = await provider.getBalance(walletContractAddress);
+    return walletBalance.gte(utils.bigNumberify(gasLimit));
+  } else if (!await isContract(provider, gasToken)) {
+    throw new InvalidContract(gasToken);
+  } else {
+    const token = new Contract(gasToken, ERC20.interface, provider);
+    const walletContractTokenBalance = await token.balanceOf(walletContractAddress);
+    return walletContractTokenBalance.gte(utils.bigNumberify(gasLimit));
+  }
+};
+
+export default class EnoughTokenValidator implements IMessageValidator {
+  constructor(private wallet: Wallet) {}
+
+  async validate(signedMessage: SignedMessage) {
+    ensure(await hasEnoughToken(signedMessage.gasToken, signedMessage.from, signedMessage.gasLimitExecution, this.wallet.provider), NotEnoughTokens);
+  }
+}

--- a/universal-login-relayer/test/integration/core/services/validators/CorrectProxyValidator.ts
+++ b/universal-login-relayer/test/integration/core/services/validators/CorrectProxyValidator.ts
@@ -1,0 +1,47 @@
+import {expect} from 'chai';
+import {Contract, Wallet, utils} from 'ethers';
+import {loadFixture} from 'ethereum-waffle';
+import {createSignedMessage, MessageWithFrom, TEST_ACCOUNT_ADDRESS, ContractWhiteList} from '@universal-login/commons';
+import basicWalletContractWithMockToken from '../../../../fixtures/basicWalletContractWithMockToken';
+import CorrectProxyValidator from '../../../../../lib/integration/ethereum/validators/CorrectProxyValidator';
+import IMessageValidator from '../../../../../lib/core/services/validators/IMessageValidator';
+import {getContractWhiteList} from '../../../../../lib/http/relayers/RelayerUnderTest';
+
+describe('INT: CorrectProxyValidator', async () => {
+  let message: MessageWithFrom;
+  let mockToken: Contract;
+  let walletContract: Contract;
+  let wallet: Wallet;
+  let validator: IMessageValidator;
+  const contractWhiteList: ContractWhiteList = getContractWhiteList();
+
+  before(async () => {
+    ({mockToken, wallet, walletContract} = await loadFixture(basicWalletContractWithMockToken));
+    message = {from: walletContract.address, gasToken: mockToken.address, to: TEST_ACCOUNT_ADDRESS};
+    validator = new CorrectProxyValidator(wallet, contractWhiteList);
+  });
+
+  it('successfully pass the validation', async () => {
+    const signedMessage = createSignedMessage({...message}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.not.be.rejected;
+  });
+
+  it('passes when not enough gas', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: 100}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.be.eventually.fulfilled;
+  });
+
+  it('passes when not enough tokens', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: utils.parseEther('2.0')}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.be.eventually.fulfilled;
+  });
+
+  it('throws when invalid proxy', async () => {
+    const messageValidatorWithInvalidProxy = new CorrectProxyValidator(wallet, {
+      wallet: [],
+      proxy: [TEST_ACCOUNT_ADDRESS]
+    });
+    const signedMessage = createSignedMessage({...message}, wallet.privateKey);
+    await expect(messageValidatorWithInvalidProxy.validate(signedMessage)).to.be.eventually.rejectedWith(`Invalid proxy at address '${signedMessage.from}'. Deployed contract bytecode hash: '${contractWhiteList.proxy[0]}'. Supported bytecode hashes: [${TEST_ACCOUNT_ADDRESS}]`);
+  });
+});

--- a/universal-login-relayer/test/integration/core/services/validators/EnoughGasValidator.ts
+++ b/universal-login-relayer/test/integration/core/services/validators/EnoughGasValidator.ts
@@ -1,0 +1,36 @@
+import {expect} from 'chai';
+import {Contract, Wallet, utils} from 'ethers';
+import {loadFixture} from 'ethereum-waffle';
+import {createSignedMessage, MessageWithFrom, TEST_ACCOUNT_ADDRESS} from '@universal-login/commons';
+import basicWalletContractWithMockToken from '../../../../fixtures/basicWalletContractWithMockToken';
+import EnoughGasValidator from '../../../../../lib/integration/ethereum/validators/EnoughGasValidator';
+import IMessageValidator from '../../../../../lib/core/services/validators/IMessageValidator';
+
+describe('INT: EnoughGasValidator', async () => {
+  let message: MessageWithFrom;
+  let mockToken: Contract;
+  let walletContract: Contract;
+  let wallet: Wallet;
+  let validator: IMessageValidator;
+
+  before(async () => {
+    ({mockToken, wallet, walletContract} = await loadFixture(basicWalletContractWithMockToken));
+    message = {from: walletContract.address, gasToken: mockToken.address, to: TEST_ACCOUNT_ADDRESS};
+    validator = new EnoughGasValidator(wallet);
+  });
+
+  it('successfully pass the validation', async () => {
+    const signedMessage = createSignedMessage({...message}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.not.be.rejected;
+  });
+
+  it('throws when not enough gas', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: 100}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.be.eventually.rejectedWith('Not enough gas');
+  });
+
+  it('passes when not enough tokens', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: utils.parseEther('2.0')}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.be.eventually.fulfilled;
+  });
+});

--- a/universal-login-relayer/test/integration/core/services/validators/EnoughTokenValidator.ts
+++ b/universal-login-relayer/test/integration/core/services/validators/EnoughTokenValidator.ts
@@ -1,0 +1,37 @@
+import {expect} from 'chai';
+import {Contract, Wallet, utils} from 'ethers';
+import {loadFixture} from 'ethereum-waffle';
+import {createSignedMessage, MessageWithFrom, TEST_ACCOUNT_ADDRESS} from '@universal-login/commons';
+import basicWalletContractWithMockToken from '../../../../fixtures/basicWalletContractWithMockToken';
+import EnoughTokenValidator from '../../../../../lib/integration/ethereum/validators/EnoughTokenValidator';
+import IMessageValidator from '../../../../../lib/core/services/validators/IMessageValidator';
+
+describe('INT: EnoughTokenValidator', async () => {
+  let message: MessageWithFrom;
+  let mockToken: Contract;
+  let walletContract: Contract;
+  let wallet: Wallet;
+  let validator: IMessageValidator;
+
+  before(async () => {
+    ({mockToken, wallet, walletContract} = await loadFixture(basicWalletContractWithMockToken));
+    message = {from: walletContract.address, gasToken: mockToken.address, to: TEST_ACCOUNT_ADDRESS};
+    validator = new EnoughTokenValidator(wallet);
+  });
+
+  it('successfully pass the validation', async () => {
+    const signedMessage = createSignedMessage({...message}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.not.be.rejected;
+  });
+
+  it('passes when not enough gas', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: 100}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.be.eventually.fulfilled;
+  });
+
+  it('throws when not enough tokens', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: utils.parseEther('2.0')}, wallet.privateKey);
+    await expect(validator.validate(signedMessage))
+      .to.be.eventually.rejectedWith('Not enough tokens');
+  });
+});


### PR DESCRIPTION
# Summary
This PR introduces validators which integrate with blockchain to validate the message:
- EnoughGasValidator
- EnoughTokenValidator
- CorrectProxyValidator

These validators will replace these lines:
https://github.com/UniversalLogin/UniversalLoginSDK/blob/3fcf7fd17815de33d7bd39b004a313e4996bf642/universal-login-relayer/lib/core/services/messages/MessageValidator.ts#L11-L13


The implementation is copied from these functions, which will replaced in another PR.