### PR TITLE
Relayer: Refactoring validations - async validator

### DIFF
--- a/universal-login-relayer/lib/core/services/validators/ComposeValidator.ts
+++ b/universal-login-relayer/lib/core/services/validators/ComposeValidator.ts
@@ -4,7 +4,9 @@ import IMessageValidator from './IMessageValidator';
 export class ComposeValidator implements IMessageValidator {
   constructor(private validators: Array<IMessageValidator>) {}
 
-  validate(signedMessage: SignedMessage) {
-    this.validators.forEach((validator) => validator.validate(signedMessage));
+  async validate(signedMessage: SignedMessage) {
+    for (let i = 0; i < this.validators.length; i++) {
+      await this.validators[i].validate(signedMessage);
+    }
   }
 }

--- a/universal-login-relayer/lib/core/services/validators/GasValidator.ts
+++ b/universal-login-relayer/lib/core/services/validators/GasValidator.ts
@@ -6,7 +6,7 @@ import IMessageValidator from './IMessageValidator';
 export const GAS_BASE = 0;
 
 export class GasValidator implements IMessageValidator {
-  validate(signedMessage: SignedMessage) {
+  async validate(signedMessage: SignedMessage) {
     const expectedGasData = estimateGasDataFromSignedMessage(signedMessage);
     const actualGasData = Number(signedMessage.gasData);
     ensure(actualGasData === expectedGasData, InsufficientGas, `Got GasData ${actualGasData} but should be ${expectedGasData}`);

--- a/universal-login-relayer/lib/core/services/validators/IMessageValidator.ts
+++ b/universal-login-relayer/lib/core/services/validators/IMessageValidator.ts
@@ -1,7 +1,7 @@
 import {SignedMessage} from '@universal-login/commons';
 
 export interface IMessageValidator {
-  validate: (message: SignedMessage) => void;
+  validate: (message: SignedMessage) => Promise<void>;
 }
 
 export default IMessageValidator;

--- a/universal-login-relayer/test/unit/core/validators/ComposeValidator.ts
+++ b/universal-login-relayer/test/unit/core/validators/ComposeValidator.ts
@@ -1,11 +1,13 @@
-import {expect} from 'chai';
+import chai, {expect} from 'chai';
 import {SignedMessage} from '@universal-login/commons';
 import {ComposeValidator} from '../../../../lib/core/services/validators/ComposeValidator';
 import {IMessageValidator} from '../../../../lib/core/services/validators/IMessageValidator';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
 
 describe('UNIT: ComposeValidator', () => {
-  const passingValidator: IMessageValidator = { validate: () => {} };
-  const createFailingValidator = (errorMsg: string) => ({ validate: () => {throw new Error(errorMsg); } } as IMessageValidator);
+  const passingValidator: IMessageValidator = { validate: async () => {} };
+  const createFailingValidator = (errorMsg: string) => ({ validate: async () => {throw new Error(errorMsg); } } as IMessageValidator);
   const message: SignedMessage = {
     to: '0xa3697367b0e19F6E9E3E7Fa1bC8b566106C68e1b',
     value: 0,
@@ -24,19 +26,19 @@ describe('UNIT: ComposeValidator', () => {
     expect(() => composeValidator.validate(message)).to.not.throw;
   });
 
-  it('ComposeValidator should fail if one individual validator fails', () => {
+  it('ComposeValidator should fail if one individual validator fails', async () => {
     const composeValidator = new ComposeValidator(
       [passingValidator, createFailingValidator('validation error')]
     );
 
-    expect(() => composeValidator.validate(message)).to.throw('validation error');
+    await expect(composeValidator.validate(message)).to.be.eventually.rejectedWith('validation error');
   });
 
-  it('ComposeValidator should fail with first error if many individual validators fail', () => {
+  it('ComposeValidator should fail with first error if many individual validators fail', async () => {
     const composeValidator = new ComposeValidator(
       [createFailingValidator('first validation error'), createFailingValidator('second validation error')]
     );
 
-    expect(() => composeValidator.validate(message)).to.throw('first validation error');
+    await expect(composeValidator.validate(message)).to.be.eventually.rejectedWith('first validation error');
   });
 });

--- a/universal-login-relayer/test/unit/core/validators/GasValidator.ts
+++ b/universal-login-relayer/test/unit/core/validators/GasValidator.ts
@@ -1,7 +1,9 @@
-import {expect} from 'chai';
+import chai, {expect} from 'chai';
 import {SignedMessage} from '@universal-login/commons';
 import {estimateGasDataFromSignedMessage} from '@universal-login/contracts';
 import {GasValidator} from '../../../../lib/core/services/validators/GasValidator';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
 
 describe('UNIT: GasValidator', () => {
   const gasValidator = new GasValidator();
@@ -23,12 +25,12 @@ describe('UNIT: GasValidator', () => {
   });
 
   it('just about right', () => {
-    expect(() => gasValidator.validate(message)).to.not.throw();
+    expect(gasValidator.validate(message)).to.be.eventually.fulfilled;
   });
 
   it('too less', () => {
     (message.gasData as number) -= 1;
     const actualGasData = estimateGasDataFromSignedMessage(message);
-    expect(() => gasValidator.validate(message)).to.throw(`Insufficient Gas. Got GasData ${message.gasData as number} but should be ${actualGasData}`);
+    expect(gasValidator.validate(message)).to.be.eventually.rejectedWith(`Insufficient Gas. Got GasData ${message.gasData as number} but should be ${actualGasData}`);
   });
 });


### PR DESCRIPTION
# Summary
The validator interface is changed to be async - in preparation for changing the [MessageValidator](https://github.com/UniversalLogin/UniversalLoginSDK/blob/master/universal-login-relayer/lib/core/services/messages/MessageValidator.ts) to be `IMessageValidator` implementation.