### PR TITLE
Relayer: Refactoring validations - Move MessageValidator

### DIFF
--- a/universal-login-relayer/lib/http/relayers/Relayer.ts
+++ b/universal-login-relayer/lib/http/relayers/Relayer.ts
@@ -25,7 +25,7 @@ import AuthorisationStore from '../../integration/sql/services/AuthorisationStor
 import WalletMasterContractService from '../../integration/ethereum/services/WalletMasterContractService';
 import {MessageStatusService} from '../../core/services/messages/MessageStatusService';
 import {SignaturesService} from '../../integration/ethereum/SignaturesService';
-import MessageValidator from '../../core/services/messages/MessageValidator';
+import MessageValidator from '../../integration/ethereum/validators/MessageValidator';
 import MessageExecutor from '../../integration/ethereum/MessageExecutor';
 import {BalanceChecker, RequiredBalanceChecker, PublicRelayerConfig} from '@universal-login/commons';
 import {DevicesStore} from '../../integration/sql/services/DevicesStore';

--- a/universal-login-relayer/lib/integration/ethereum/MessageExecutor.ts
+++ b/universal-login-relayer/lib/integration/ethereum/MessageExecutor.ts
@@ -1,7 +1,7 @@
 import {Wallet, providers} from 'ethers';
 import {SignedMessage} from '@universal-login/commons';
 import {messageToTransaction} from '../../core/utils/utils';
-import MessageValidator from '../../core/services/messages/MessageValidator';
+import MessageValidator from './validators/MessageValidator';
 
 export class MessageExecutor {
 

--- a/universal-login-relayer/lib/integration/ethereum/validators/MessageValidator.ts
+++ b/universal-login-relayer/lib/integration/ethereum/validators/MessageValidator.ts
@@ -1,7 +1,7 @@
 import {Wallet, providers, utils} from 'ethers';
 import {ContractWhiteList, SignedMessage, ensure} from '@universal-login/commons';
-import {ensureEnoughGas, ensureEnoughToken} from '../../../integration/ethereum/validations';
-import {InvalidProxy} from '../../utils/errors';
+import {ensureEnoughGas, ensureEnoughToken} from '../validations';
+import {InvalidProxy} from '../../../core/utils/errors';
 
 export class MessageValidator {
   constructor(private wallet: Wallet, private contractWhiteList: ContractWhiteList) {

--- a/universal-login-relayer/test/helpers/setupMessageService.js
+++ b/universal-login-relayer/test/helpers/setupMessageService.js
@@ -8,7 +8,7 @@ import MessageSQLRepository from '../../lib/integration/sql/services/MessageSQLR
 import {getContractWhiteList} from '../../lib/http/relayers/RelayerUnderTest';
 import {MessageStatusService} from '../../lib/core/services/messages/MessageStatusService';
 import {SignaturesService} from '../../lib/integration/ethereum/SignaturesService';
-import MessageValidator from '../../lib/core/services/messages/MessageValidator';
+import MessageValidator from '../../lib/integration/ethereum/validators/MessageValidator';
 import MessageExecutor from '../../lib/integration/ethereum/MessageExecutor';
 import {DevicesStore} from '../../lib/integration/sql/services/DevicesStore';
 import {DevicesService} from '../../lib/core/services/DevicesService';

--- a/universal-login-relayer/test/integration/core/services/messages/MessageValidator.ts
+++ b/universal-login-relayer/test/integration/core/services/messages/MessageValidator.ts
@@ -3,7 +3,7 @@ import {Contract, Wallet, utils, providers} from 'ethers';
 import {loadFixture} from 'ethereum-waffle';
 import {createSignedMessage, MessageWithFrom, TEST_ACCOUNT_ADDRESS, ContractWhiteList} from '@universal-login/commons';
 import basicWalletContractWithMockToken from '../../../../fixtures/basicWalletContractWithMockToken';
-import MessageValidator from '../../../../../lib/core/services/messages/MessageValidator';
+import MessageValidator from '../../../../../lib/integration/ethereum/validators/MessageValidator';
 import {messageToTransaction} from '../../../../../lib/core/utils/utils';
 import {getContractWhiteList} from '../../../../../lib/http/relayers/RelayerUnderTest';
 


### PR DESCRIPTION
# Summary
The `MessageValidator` is moved from `core` to `integration/ethereum`, as it connects to the blockchain