### PR TITLE
Relayer: Refactor correct proxy validation

### DIFF
--- a/universal-login-relayer/lib/integration/ethereum/validators/CorrectProxyValidator.ts
+++ b/universal-login-relayer/lib/integration/ethereum/validators/CorrectProxyValidator.ts
@@ -1,0 +1,19 @@
+import {Wallet, utils} from 'ethers';
+import {ContractWhiteList, SignedMessage, ensure} from '@universal-login/commons';
+import IMessageValidator from '../../../core/services/validators/IMessageValidator';
+import {InvalidProxy} from '../../../core/utils/errors';
+
+export default class CorrectProxyValidator implements IMessageValidator {
+  constructor(private wallet: Wallet, private contractWhiteList: ContractWhiteList) {}
+
+  async validate(signedMessage: SignedMessage) {
+    const proxyByteCode = await this.wallet.provider.getCode(signedMessage.from);
+    const proxyContractHash = utils.keccak256(proxyByteCode);
+    ensure(
+      this.contractWhiteList.proxy.includes(proxyContractHash),
+      InvalidProxy,
+      signedMessage.from,
+      proxyContractHash,
+      this.contractWhiteList.proxy);
+  }
+}

--- a/universal-login-relayer/lib/integration/ethereum/validators/MessageValidator.ts
+++ b/universal-login-relayer/lib/integration/ethereum/validators/MessageValidator.ts
@@ -1,31 +1,24 @@
-import {Wallet, providers, utils} from 'ethers';
-import {ContractWhiteList, SignedMessage, ensure} from '@universal-login/commons';
-import {IMessageValidator} from '../../../core/services/validators/IMessageValidator';
+import {Wallet, providers} from 'ethers';
+import {ContractWhiteList, SignedMessage} from '@universal-login/commons';
+import {ComposeValidator} from '../../../core/services/validators/ComposeValidator';
+import CorrectProxyValidator from '../../../integration/ethereum/validators/CorrectProxyValidator';
 import {ensureEnoughGas, ensureEnoughToken} from '../validations';
-import {InvalidProxy} from '../../../core/utils/errors';
 import {messageToTransaction} from '../../../core/utils/messages/serialisation';
 
-export class MessageValidator implements IMessageValidator {
-  constructor(private wallet: Wallet, private contractWhiteList: ContractWhiteList) {
+export class MessageValidator extends ComposeValidator {
+  constructor(private wallet: Wallet, contractWhiteList: ContractWhiteList) {
+    super([
+      new CorrectProxyValidator(wallet, contractWhiteList)
+    ]);
   }
 
   async validate(signedMessage: SignedMessage) : Promise<void> {
-    await this.ensureCorrectProxy(signedMessage.from);
+    await super.validate(signedMessage);
+
     await ensureEnoughToken(this.wallet.provider, signedMessage);
 
     const transactionReq: providers.TransactionRequest = messageToTransaction(signedMessage);
     await ensureEnoughGas(this.wallet.provider, this.wallet.address, transactionReq, signedMessage);
-  }
-
-  private async ensureCorrectProxy(from: string) {
-    const proxyByteCode = await this.wallet.provider.getCode(from);
-    const proxyContractHash = utils.keccak256(proxyByteCode);
-    ensure(
-      this.contractWhiteList.proxy.includes(proxyContractHash),
-      InvalidProxy,
-      from,
-      proxyContractHash,
-      this.contractWhiteList.proxy);
   }
 }
 

--- a/universal-login-relayer/test/integration/integration/ethereum/validators/CorrectProxyValidator.ts
+++ b/universal-login-relayer/test/integration/integration/ethereum/validators/CorrectProxyValidator.ts
@@ -1,0 +1,47 @@
+import {expect} from 'chai';
+import {Contract, Wallet, utils} from 'ethers';
+import {loadFixture} from 'ethereum-waffle';
+import {createSignedMessage, MessageWithFrom, TEST_ACCOUNT_ADDRESS, ContractWhiteList} from '@universal-login/commons';
+import basicWalletContractWithMockToken from '../../../../fixtures/basicWalletContractWithMockToken';
+import CorrectProxyValidator from '../../../../../lib/integration/ethereum/validators/CorrectProxyValidator';
+import IMessageValidator from '../../../../../lib/core/services/validators/IMessageValidator';
+import {getContractWhiteList} from '../../../../../lib/http/relayers/RelayerUnderTest';
+
+describe('INT: CorrectProxyValidator', async () => {
+  let message: MessageWithFrom;
+  let mockToken: Contract;
+  let walletContract: Contract;
+  let wallet: Wallet;
+  let validator: IMessageValidator;
+  const contractWhiteList: ContractWhiteList = getContractWhiteList();
+
+  before(async () => {
+    ({mockToken, wallet, walletContract} = await loadFixture(basicWalletContractWithMockToken));
+    message = {from: walletContract.address, gasToken: mockToken.address, to: TEST_ACCOUNT_ADDRESS};
+    validator = new CorrectProxyValidator(wallet, contractWhiteList);
+  });
+
+  it('successfully pass the validation', async () => {
+    const signedMessage = createSignedMessage({...message}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.not.be.rejected;
+  });
+
+  it('passes when not enough gas', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: 100}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.be.eventually.fulfilled;
+  });
+
+  it('passes when not enough tokens', async () => {
+    const signedMessage = createSignedMessage({...message, gasLimitExecution: utils.parseEther('2.0')}, wallet.privateKey);
+    await expect(validator.validate(signedMessage)).to.be.eventually.fulfilled;
+  });
+
+  it('throws when invalid proxy', async () => {
+    const messageValidatorWithInvalidProxy = new CorrectProxyValidator(wallet, {
+      wallet: [],
+      proxy: [TEST_ACCOUNT_ADDRESS]
+    });
+    const signedMessage = createSignedMessage({...message}, wallet.privateKey);
+    await expect(messageValidatorWithInvalidProxy.validate(signedMessage)).to.be.eventually.rejectedWith(`Invalid proxy at address '${signedMessage.from}'. Deployed contract bytecode hash: '${contractWhiteList.proxy[0]}'. Supported bytecode hashes: [${TEST_ACCOUNT_ADDRESS}]`);
+  });
+});


### PR DESCRIPTION
# Summary
- Introduces `CorrectProxyValidator`, replacing code in `MessageValidator`
- Changed `MessageValidator` to be of `ComposeValidator` type, in preparation for refactoring `ensureEnoughToken` and `ensureEnoughGas`