### PR TITLE
Wallet: Unify copy button

### DIFF
--- a/universal-login-wallet/src/ui/styles/components/_top-up.sass
+++ b/universal-login-wallet/src/ui/styles/components/_top-up.sass
@@ -161,7 +161,7 @@
   display: flex
   align-items: center
   background: #FFFFFF
-  border: 1px solid #E1E1F0
+  border: none
 
 .universal-login-topup .jarvis-topup .top-up-label
   display: block
@@ -178,7 +178,7 @@
   background: #FFFFFF
   font-size: 14px
   color: #6e798e
-  border: none
+  border: 1px solid #E1E1F0
 
 .universal-login-topup .jarvis-topup .address-modal-text
   margin-top: 12px


### PR DESCRIPTION
# Summary
Copy button was different in topUp and wallet itself. Also in topUp border was for whole wrapper not only the input which during focus provide a strange visual effect.

Fixes: 1

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

