### PR TITLE
Wallet: Add max button functionality to transfers

### DIFF
--- a/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
+++ b/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
@@ -19,6 +19,7 @@ export interface TransferAmountProps {
 export const TransferAmount = ({sdk, ensName, onSelectRecipientClick, updateTransferDetailsWith, currency, transferAmountClassName}: TransferAmountProps) => {
   const [tokenDetailsWithBalance, setTokenDetailsWithBalance] = useState<TokenDetailsWithBalance[]>([]);
   const [isAmountCorrect, setIsAmountCorrect] = useState(false);
+  const [amount, setAmount] = useState('');
 
   useAsyncEffect(() => sdk.subscribeToBalances(ensName, setTokenDetailsWithBalance), []);
   const balance = getBalanceOf(currency, tokenDetailsWithBalance);
@@ -29,6 +30,7 @@ export const TransferAmount = ({sdk, ensName, onSelectRecipientClick, updateTran
     } else {
       setIsAmountCorrect(false);
     }
+    setAmount(amount);
     updateTransferDetailsWith({amount});
   };
 
@@ -45,7 +47,7 @@ export const TransferAmount = ({sdk, ensName, onSelectRecipientClick, updateTran
         />
         <div className="transfer-amount-row">
           <label className="transfer-amount-label" htmlFor="amount-eth">How much are you sending?</label>
-          <button className="transfer-amount-max">Max</button>
+          <button id="max-button" className="transfer-amount-max" onClick={() => validateAndUpdateTransferDetails(balance!)}>Max</button>
         </div>
         <div className="transfer-amount-input-wrapper">
           <input
@@ -53,6 +55,7 @@ export const TransferAmount = ({sdk, ensName, onSelectRecipientClick, updateTran
             type="number"
             className="transfer-amount-input"
             onChange={event => validateAndUpdateTransferDetails(event.target.value)}
+            value={amount}
           />
           <span className="transfer-amount-code">{currency}</span>
         </div>

--- a/universal-login-sdk/lib/integration/ethereum/TransferService.ts
+++ b/universal-login-sdk/lib/integration/ethereum/TransferService.ts
@@ -1,8 +1,9 @@
 import {utils} from 'ethers';
 import IERC20 from 'openzeppelin-solidity/build/contracts/IERC20.json';
-import {ETHER_NATIVE_TOKEN, ensure, ensureNotNull, isProperAddress, TransferDetails, ApplicationWallet} from '@universal-login/commons';
+import {ETHER_NATIVE_TOKEN, ensure, ensureNotNull, isProperAddress, TransferDetails, ApplicationWallet, Message, SignedMessage, createSignedMessage} from '@universal-login/commons';
 import UniversalLoginSDK from '../../api/sdk';
 import {ApplicationWalletNotFound, InvalidAddress} from '../../core/utils/errors';
+import {messageToUnsignedMessage, encodeDataForExecuteSigned} from '@universal-login/contracts';
 
 export class TransferService {
   constructor(private sdk: UniversalLoginSDK, private applicationWallet: ApplicationWallet) {}
@@ -18,29 +19,61 @@ export class TransferService {
   }
 
   private async transferTokens({to, amount, currency} : TransferDetails) {
-      const tokenAddress = this.sdk.tokensDetailsStore.getTokenAddress(currency);
-      const message = {
-        from: this.applicationWallet!.contractAddress,
-        to: tokenAddress,
-        value: 0,
-        data: encodeTransfer(to, amount),
-        gasToken: tokenAddress
-      };
-      return this.sdk.execute(message, this.applicationWallet!.privateKey);
+    const tokenAddress = this.sdk.tokensDetailsStore.getTokenAddress(currency);
+    let message: Partial<Message> = {
+      from: this.applicationWallet!.contractAddress,
+      to: tokenAddress,
+      value: 0,
+      data: encodeTransfer(to, utils.parseEther(amount)),
+      gasToken: tokenAddress
+    };
+    message = await this.changeMessageIfAmountMax(message, utils.parseEther(amount), to);
+    return this.sdk.execute(message, this.applicationWallet!.privateKey);
   }
 
   private async transferEther({to, amount} : TransferDetails) {
-      const message = {
-        from: this.applicationWallet!.contractAddress,
-        to,
-        value: utils.parseEther(amount),
-        data: '0x',
-        gasToken: ETHER_NATIVE_TOKEN.address
-      };
-      return this.sdk.execute(message, this.applicationWallet!.privateKey);
+    let message: Partial<Message> = {
+      from: this.applicationWallet!.contractAddress,
+      to,
+      value: utils.parseEther(amount),
+      data: '0x',
+      gasToken: ETHER_NATIVE_TOKEN.address
+    };
+    message = await this.changeMessageIfAmountMax(message, utils.parseEther(amount));
+    return this.sdk.execute(message, this.applicationWallet!.privateKey);
   }
+
+  public async changeMessageIfAmountMax(message: Partial<Message>, amount: utils.BigNumber, to?: string) {
+    if (await this.checkIfAmountIsMax(message.gasToken!, amount)) {
+      if (message.gasToken === ETHER_NATIVE_TOKEN.address) {
+        return {...message, ...{value: await this.calculateNewAmount(message, amount)}};
+      }
+      return {...message, ...{data: encodeTransfer(to!, await this.calculateNewAmount(message, amount))}};
+    }
+    return message;
+  }
+
+  public async checkIfAmountIsMax(tokenAddress: string, amount: utils.BigNumber) {
+    return (await this.sdk.balanceChecker.getBalance(this.applicationWallet.contractAddress, tokenAddress)).eq(amount);
+  }
+
+  public async calculateNewAmount(message: Partial<Message>, amount: utils.BigNumber) {
+    const unsignedMessage = await this.getUnsignedMessage(message);
+    const signedMessage: SignedMessage = createSignedMessage(unsignedMessage, this.applicationWallet.privateKey);
+    const metaTransaction = {to: message.from, value: 0, data: encodeDataForExecuteSigned(signedMessage)};
+    const estimatedGasUsed = (await this.sdk.provider.estimateGas(metaTransaction)).add(await this.sdk.provider.estimateGas(message));
+    const estimatedGasCost = estimatedGasUsed.mul(utils.bigNumberify(this.sdk.sdkConfig.paymentOptions.gasPrice));
+    return amount.sub(estimatedGasCost);
+  }
+
+  private async getUnsignedMessage(message: Partial<Message>) {
+    const {gasLimit, gasPrice} = this.sdk.sdkConfig.paymentOptions;
+    const unsignedMessage = messageToUnsignedMessage({gasLimit, gasPrice, ...message});
+    unsignedMessage.nonce = await this.sdk.getNonce(message.from!);
+    return unsignedMessage;
+    }
 }
 
-export function encodeTransfer(to: string, amount: string) {
-  return new utils.Interface(IERC20.abi).functions.transfer.encode([to, utils.parseEther(amount)]);
-}
+export const encodeTransfer = (to: string, amount: utils.BigNumber) => {
+  return new utils.Interface(IERC20.abi).functions.transfer.encode([to, amount]);
+};

--- a/universal-login-wallet/test/integration/pages/TransferPage.ts
+++ b/universal-login-wallet/test/integration/pages/TransferPage.ts
@@ -17,13 +17,22 @@ export default class TransferPage {
   }
 
   enterTransferAmount(amount: string) {
+    this.appWrapper.find('#max-button').simulate('click');
     const amountInput = this.appWrapper.find('input#amount-eth');
     amountInput.simulate('change', {target: {value: amount}});
-    this.appWrapper.find('#select-recipient').simulate('click');
+    this.clickSelectRecipient();
   }
 
   enterRecipient(address: string) {
     const addressInput = this.appWrapper.find('input#input-recipient');
     addressInput.simulate('change', {target: {value: address}});
+  }
+
+  clickSelectRecipient() {
+    this.appWrapper.find('#select-recipient').simulate('click');
+  }
+
+  clickMaxAmountButton() {
+    this.appWrapper.find('#max-button').simulate('click');
   }
 }

--- a/universal-login-wallet/test/integration/ui/Transfer.tsx
+++ b/universal-login-wallet/test/integration/ui/Transfer.tsx
@@ -26,11 +26,11 @@ describe('UI: Transfer', () => {
     ({relayer, provider} = await setupSdk(wallet, '33113'));
     ({mockTokenContract} = await createFixtureLoader(provider as providers.Web3Provider)(deployMockToken));
     ({appWrapper, appPage, services} = await setupUI(relayer, mockTokenContract.address));
+    const walletAddress = services.walletService.state.kind === 'Deployed' ? services.walletService.getDeployedWallet().contractAddress : '0x0';
+    await mockTokenContract.transfer(walletAddress, utils.parseEther('2.0'));
   });
 
   it('Creates wallet and transfers ethers', async () => {
-    const walletAddress = services.walletService.state.kind === 'Deployed' ? services.walletService.getDeployedWallet().contractAddress : '0x0';
-    await mockTokenContract.transfer(walletAddress, utils.parseEther('2.0'));
     appPage.dashboard().clickTransferButton();
     await appPage.transfer().chooseCurrency('ETH');
     appPage.transfer().enterTransferAmount('1');
@@ -38,6 +38,18 @@ describe('UI: Transfer', () => {
     appPage.transfer().transfer();
     await appPage.dashboard().waitForHideModal();
     expect(appPage.dashboard().getWalletBalance()).to.match(/^\$0\.9{2}[0-9]{6}/);
+  });
+
+  it('Creates wallet and transfers max amount of ethers', async () => {
+    appPage.dashboard().clickTransferButton();
+    await appPage.transfer().chooseCurrency('ETH');
+    appPage.transfer().clickMaxAmountButton();
+    appPage.transfer().clickSelectRecipient();
+    appPage.transfer().enterRecipient(receiverAddress);
+    appPage.transfer().transfer();
+    await appPage.dashboard().waitForHideModal();
+    const amountLeft = appPage.dashboard().getWalletBalance().replace('$', '');
+    expect(Number(amountLeft)).to.be.lt(0.000004);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
# Summary
Add functionality to Max button in Transfer Modal. Unfortunately, the estimation of gas used is not 100% accurate which leads to the situation that after sending max amount the user would still have a small amount of ether/token. Additionally, even in the test, estimations are not always the same which means test cannot be consistent, this is why I used greater/lesser than in test. 

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

