### PR TITLE
Commons: Change yellow color of emoji

### DIFF
--- a/universal-login-commons/lib/core/constants/emojiColors.ts
+++ b/universal-login-commons/lib/core/constants/emojiColors.ts
@@ -1,6 +1,6 @@
 export const EMOJI_COLORS = [
   '#B9C3F8',
-  '#F5FF98',
+  '#E7D300',
   '#0FB989',
   '#FFAEFC',
   '#3C93FF',


### PR DESCRIPTION
# Summary
Changed yellow color of emoji because it is too bright

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

