### PR TITLE
Wallet: Fix cancel and try to connect once again

### DIFF
--- a/universal-login-wallet/src/ui/react/ConnectAccount/ConnectWithEmoji.tsx
+++ b/universal-login-wallet/src/ui/react/ConnectAccount/ConnectWithEmoji.tsx
@@ -19,6 +19,7 @@ export const ConnectWithEmoji = ({name, setConnectModal}: ConnectWithEmojiProps)
   const onCancelClick = async () => {
     const {contractAddress, privateKey} = walletService.getConnectingWallet();
     await sdk.cancelRequest(contractAddress, privateKey);
+    walletService.disconnect();
 
     connectValues!.unsubscribe();
     setConnectModal('connectionMethod');


### PR DESCRIPTION
# Summary
Fix situation when user click cancels during connecting to a new device and then click connect passwordless. Currently, the app would fail with the error, cannot overwrite wallet.

Fixes: 1

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

