### PR TITLE
Wallet: Add handling when authorization not found

### DIFF
--- a/universal-login-relayer/lib/http/routes/authorisation.ts
+++ b/universal-login-relayer/lib/http/routes/authorisation.ts
@@ -35,8 +35,8 @@ const denyRequest = (authorisationService: AuthorisationService) =>
 const cancelRequest = (authorisationService: AuthorisationService) =>
   async (data: {body: {authorisationRequest: RelayerRequest}}) => {
     const result = await authorisationService.cancelAuthorisationRequest(data.body.authorisationRequest);
-    const httpCode = result === 0 ? 401 : 204;
-    return responseOf(result, httpCode);
+    const httpCode = result === 0 ? 404 : 204;
+    return responseOf({response: result}, httpCode);
   };
 
 export default (authorisationService: AuthorisationService) => {

--- a/universal-login-relayer/test/e2e/authorisations.js
+++ b/universal-login-relayer/test/e2e/authorisations.js
@@ -118,7 +118,7 @@ describe('E2E: Relayer - Authorisation routes', async () => {
       const {status} = await chai.request(relayer.server)
         .delete(`/authorisation/${contract.address}`)
         .send({authorisationRequest});
-      expect(status).to.eq(401);
+      expect(status).to.eq(404);
 
       const {response} = await getAuthorisation(relayer, contract, keyPair);
       expect(response).to.have.lengthOf(1);

--- a/universal-login-wallet/src/ui/react/ConnectAccount/ConnectWithEmoji.tsx
+++ b/universal-login-wallet/src/ui/react/ConnectAccount/ConnectWithEmoji.tsx
@@ -4,6 +4,7 @@ import vault1x from './../../assets/illustrations/vault.png';
 import vault2x from './../../assets/illustrations/vault@2x.png';
 import {useServices, useRouter} from '../../hooks';
 import {ConnectModal} from './ConnectAccount';
+import {ensure} from '@universal-login/commons';
 
 
 interface ConnectWithEmojiProps {
@@ -18,11 +19,18 @@ export const ConnectWithEmoji = ({name, setConnectModal}: ConnectWithEmojiProps)
 
   const onCancelClick = async () => {
     const {contractAddress, privateKey} = walletService.getConnectingWallet();
-    await sdk.cancelRequest(contractAddress, privateKey);
+    await cancelRequest(contractAddress, privateKey);
     walletService.disconnect();
-
     connectValues!.unsubscribe();
     setConnectModal('connectionMethod');
+  };
+
+  const cancelRequest = async (contractAddress: string, privateKey: string) => {
+    try {
+      await sdk.cancelRequest(contractAddress, privateKey);
+    } catch (error) {
+      ensure(error.response === 0, Error, 'Invalid cancel request');
+    }
   };
 
   return (


### PR DESCRIPTION
# Summary
Added handling to the situation when a user on the first device denies connecting and the user on the second device cancel the request. Currently, this situation would produce error.

Fixes: 1

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

