### PR TITLE
Sdk: Remove unnecessary getWalletContractAddress call

### DIFF
--- a/universal-login-react/src/ui/Transfer/Amount/ModalTransferAmount.tsx
+++ b/universal-login-react/src/ui/Transfer/Amount/ModalTransferAmount.tsx
@@ -6,7 +6,7 @@ import {getStyleForTopLevelComponent} from '../../../core/utils/getStyleForTopLe
 
 export interface ModalTransferAmountProps {
   sdk: UniversalLoginSDK;
-  ensName: string;
+  contractAddress: string;
   onSelectRecipientClick: () => void;
   updateTransferDetailsWith: (transferDetails: Partial<TransferDetails>) => void;
   currency: string;
@@ -16,7 +16,7 @@ export interface ModalTransferAmountProps {
 
 export const ModalTransferAmount = ({
   sdk,
-  ensName,
+  contractAddress,
   onSelectRecipientClick,
   updateTransferDetailsWith,
   currency,
@@ -33,7 +33,7 @@ export const ModalTransferAmount = ({
           <div className="modal-content">
             <TransferAmount
               sdk={sdk}
-              ensName={ensName}
+              contractAddress={contractAddress}
               onSelectRecipientClick={onSelectRecipientClick}
               updateTransferDetailsWith={updateTransferDetailsWith}
               currency={currency}

--- a/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
+++ b/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
@@ -9,18 +9,18 @@ import {useAsyncEffect} from '../../hooks/useAsyncEffect';
 
 export interface TransferAmountProps {
   sdk: UniversalLoginSDK;
-  ensName: string;
+  contractAddress: string;
   onSelectRecipientClick: () => void;
   updateTransferDetailsWith: (transferDetails: Partial<TransferDetails>) => void;
   currency: string;
   transferAmountClassName?: string;
 }
 
-export const TransferAmount = ({sdk, ensName, onSelectRecipientClick, updateTransferDetailsWith, currency, transferAmountClassName}: TransferAmountProps) => {
+export const TransferAmount = ({sdk, contractAddress, onSelectRecipientClick, updateTransferDetailsWith, currency, transferAmountClassName}: TransferAmountProps) => {
   const [tokenDetailsWithBalance, setTokenDetailsWithBalance] = useState<TokenDetailsWithBalance[]>([]);
   const [isAmountCorrect, setIsAmountCorrect] = useState(false);
 
-  useAsyncEffect(() => sdk.subscribeToBalances(ensName, setTokenDetailsWithBalance), []);
+  useAsyncEffect(() => sdk.subscribeToBalances(contractAddress, setTokenDetailsWithBalance), []);
   const balance = getBalanceOf(currency, tokenDetailsWithBalance);
 
   const validateAndUpdateTransferDetails = (amount: string) => {

--- a/universal-login-react/src/ui/UFlow/Funds.tsx
+++ b/universal-login-react/src/ui/UFlow/Funds.tsx
@@ -21,7 +21,7 @@ interface FundsProps {
 export const Funds = ({contractAddress, ensName, sdk, onTopUpClick, onSendClick, className}: FundsProps) => {
   const [totalTokensValue, setTotalTokensValue] = useState<CurrencyToValue>({} as CurrencyToValue);
 
-  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(ensName, setTotalTokensValue), []);
+  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(contractAddress, setTotalTokensValue), []);
 
   return (
     <div className="universal-login-funds">
@@ -41,7 +41,7 @@ export const Funds = ({contractAddress, ensName, sdk, onTopUpClick, onSendClick,
           </div>
           <Assets
             sdk={sdk}
-            ensName={ensName}
+            contractAddress={contractAddress}
             className={className}
           />
         </div>

--- a/universal-login-react/src/ui/UFlow/UDashboard.tsx
+++ b/universal-login-react/src/ui/UFlow/UDashboard.tsx
@@ -65,7 +65,7 @@ export const UDashboard = ({applicationWallet, sdk}: UDashboardProps) => {
         return (
           <TransferAmount
             sdk={sdk}
-            ensName={applicationWallet.name}
+            contractAddress={applicationWallet.contractAddress}
             onSelectRecipientClick={() => setDashboardContent('transferRecipient')}
             updateTransferDetailsWith={updateTransferDetailsWith}
             currency={transferDetails.currency}

--- a/universal-login-react/src/ui/commons/Assets.tsx
+++ b/universal-login-react/src/ui/commons/Assets.tsx
@@ -12,16 +12,16 @@ import {getStyleForTopLevelComponent} from '../../core/utils/getStyleForTopLevel
 
 export interface AssetsProps {
   sdk: UniversalLoginSDK;
-  ensName: string;
+  contractAddress: string;
   className?: string;
 }
 
 const iconForToken = (symbol: string) => symbol === 'ETH' ? ethIcon : daiIcon;
 
-export const Assets = ({sdk, ensName, className}: AssetsProps) => {
+export const Assets = ({sdk, contractAddress, className}: AssetsProps) => {
   const [tokenDetailsWithBalance, setTokenDetailsWithBalance] = useState<TokenDetailsWithBalance[]>([]);
 
-  useAsyncEffect(() => sdk.subscribeToBalances(ensName, setTokenDetailsWithBalance), []);
+  useAsyncEffect(() => sdk.subscribeToBalances(contractAddress, setTokenDetailsWithBalance), []);
 
   return (
     <div className="universal-login-assets">

--- a/universal-login-sdk/lib/api/DeployedWallet.ts
+++ b/universal-login-sdk/lib/api/DeployedWallet.ts
@@ -103,6 +103,6 @@ export class DeployedWallet implements ApplicationWallet {
   }
 
   subscribeToBalances(callback: OnBalanceChange) {
-    return this.sdk.subscribeToBalances(this.name, callback);
+    return this.sdk.subscribeToBalances(this.contractAddress, callback);
   }
 }

--- a/universal-login-sdk/lib/api/sdk.ts
+++ b/universal-login-sdk/lib/api/sdk.ts
@@ -97,23 +97,22 @@ class UniversalLoginSDK {
     return this.relayerConfig;
   }
 
-  async fetchBalanceObserver(ensName: string) {
+  async fetchBalanceObserver(contractAddress: string) {
     if (this.balanceObserver) {
       return;
     }
-    const walletContractAddress = await this.getWalletContractAddress(ensName);
-    ensureNotNull(walletContractAddress, InvalidContract);
-    ensureNotNull(this.relayerConfig, MissingConfiguration);
+    ensureNotNull(contractAddress, InvalidContract);
+    ensureNotNull(this.sdkConfig, MissingConfiguration);
 
     await this.tokensDetailsStore.fetchTokensDetails();
-    this.balanceObserver = new BalanceObserver(this.balanceChecker, walletContractAddress, this.tokensDetailsStore);
+    this.balanceObserver = new BalanceObserver(this.balanceChecker, contractAddress, this.tokensDetailsStore);
   }
 
-  async fetchAggregateBalanceObserver(ensName: string) {
+  async fetchAggregateBalanceObserver(contractAddress: string) {
     if (this.aggregateBalanceObserver) {
       return;
     }
-    await this.fetchBalanceObserver(ensName);
+    await this.fetchBalanceObserver(contractAddress);
     this.aggregateBalanceObserver = new AggregateBalanceObserver(this.balanceObserver!, this.priceObserver, this.tokensValueConverter);
   }
 
@@ -213,13 +212,13 @@ class UniversalLoginSDK {
     return this.blockchainObserver.subscribe(eventType, filter, callback);
   }
 
-  async subscribeToBalances(ensName: string, callback: OnBalanceChange) {
-    await this.fetchBalanceObserver(ensName);
+  async subscribeToBalances(contractAddress: string, callback: OnBalanceChange) {
+    await this.fetchBalanceObserver(contractAddress);
     return this.balanceObserver!.subscribe(callback);
   }
 
-  async subscribeToAggregatedBalance(ensName: string, callback: OnAggregatedBalanceChange) {
-    await this.fetchAggregateBalanceObserver(ensName);
+  async subscribeToAggregatedBalance(contractAddress: string, callback: OnAggregatedBalanceChange) {
+    await this.fetchAggregateBalanceObserver(contractAddress);
     return this.aggregateBalanceObserver!.subscribe(callback);
   }
 

--- a/universal-login-sdk/test/e2e/BalanceObserver.ts
+++ b/universal-login-sdk/test/e2e/BalanceObserver.ts
@@ -12,12 +12,11 @@ const loadFixture = createFixtureLoader();
 describe('E2E: BalanceObserver', () => {
   let sdk: UniversalLoginSDK;
   let relayer: RelayerUnderTest;
-  let ensName: string;
   let wallet: Wallet;
   let contractAddress: string;
 
   beforeEach(async () => {
-    ({sdk, relayer, ensName, wallet, contractAddress} = await loadFixture(basicSDK));
+    ({sdk, relayer, wallet, contractAddress} = await loadFixture(basicSDK));
   });
 
   it('1 subscription', async () => {

--- a/universal-login-sdk/test/e2e/BalanceObserver.ts
+++ b/universal-login-sdk/test/e2e/BalanceObserver.ts
@@ -23,7 +23,7 @@ describe('E2E: BalanceObserver', () => {
   it('1 subscription', async () => {
     const callback = sinon.spy();
 
-    const unsubscribe = await sdk.subscribeToBalances(ensName, callback);
+    const unsubscribe = await sdk.subscribeToBalances(contractAddress, callback);
     await waitUntil(() => !!callback.firstCall);
     unsubscribe();
 
@@ -33,7 +33,7 @@ describe('E2E: BalanceObserver', () => {
   it('1 subscription - balance changed', async () => {
     const callback = sinon.spy();
 
-    const unsubscribe = await sdk.subscribeToBalances(ensName, callback);
+    const unsubscribe = await sdk.subscribeToBalances(contractAddress, callback);
     await waitUntil(() => !!callback.firstCall);
 
     await wallet.sendTransaction({to: contractAddress, value: utils.parseEther('0.5')});
@@ -47,10 +47,10 @@ describe('E2E: BalanceObserver', () => {
     const callback1 = sinon.spy();
     const callback2 = sinon.spy();
 
-    const unsubscribe1 = await sdk.subscribeToBalances(ensName, callback1);
+    const unsubscribe1 = await sdk.subscribeToBalances(contractAddress, callback1);
     await waitUntil(() => !!callback1.firstCall);
 
-    const unsubscribe2 = await sdk.subscribeToBalances(ensName, callback2);
+    const unsubscribe2 = await sdk.subscribeToBalances(contractAddress, callback2);
     await waitUntil(() => !!callback2.firstCall);
 
     unsubscribe1();

--- a/universal-login-wallet/src/ui/react/Home/Balance.tsx
+++ b/universal-login-wallet/src/ui/react/Home/Balance.tsx
@@ -11,7 +11,7 @@ const Balance = () => {
   const [totalBalance, setTotalBalance] = useState<number>(0);
   const {sdk, walletPresenter} = useServices();
 
-  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(walletPresenter.getName(), (totalBalances: CurrencyToValue) => setTotalBalance(totalBalances['USD'])), []);
+  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(walletPresenter.getContractAddress(), (totalBalances: CurrencyToValue) => setTotalBalance(totalBalances['USD'])), []);
 
   return(
     <section className="balance">

--- a/universal-login-wallet/src/ui/react/Modals/Transfer/ModalTransfer.tsx
+++ b/universal-login-wallet/src/ui/react/Modals/Transfer/ModalTransfer.tsx
@@ -36,7 +36,7 @@ const ModalTransfer = () => {
     return (
       <ModalTransferAmount
         sdk={sdk}
-        ensName={applicationWallet.name}
+        contractAddress={applicationWallet.contractAddress}
         onSelectRecipientClick={() => setModal('transferRecipient')}
         updateTransferDetailsWith={updateTransferDetailsWith}
         currency={transferDetails.currency}


### PR DESCRIPTION
# Summary
Remove unnecessary getWalletContractAddress call when fetching balances.

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

