### PR TITLE
Add IP-Geolocation Api config to Relayer config

### DIFF
--- a/universal-login-commons/lib/core/models/IPGeolocationApiConfig.ts
+++ b/universal-login-commons/lib/core/models/IPGeolocationApiConfig.ts
@@ -1,0 +1,4 @@
+export interface IPGeolocationApiConfig {
+  baseUrl: string;
+  accessKey: string;
+}

--- a/universal-login-commons/lib/core/models/relayer.ts
+++ b/universal-login-commons/lib/core/models/relayer.ts
@@ -1,4 +1,5 @@
 import {LocalizationConfig, SafelloConfig, RampConfig} from './onRamp';
+import {IPGeolocationApiConfig} from './IPGeolocationApiConfig';
 
 export interface SupportedToken {
   address: string;
@@ -29,4 +30,5 @@ export interface PublicRelayerConfig {
   localization: LocalizationConfig;
   onRampProviders: OnRampConfig;
   maxGasLimit: number;
+  ipGeolocationApi: IPGeolocationApiConfig;
 }

--- a/universal-login-commons/lib/index.ts
+++ b/universal-login-commons/lib/index.ts
@@ -69,3 +69,4 @@ export {convertTenthGweiToWei} from './core/utils/conversion';
 export {computeGasData} from './core/utils/messages/computeGasData';
 export {getEnumKeys} from './core/utils/getEnumsKeys';
 export {stringToEnumKey} from './core/utils/stringToEnumKey';
+export {IPGeolocationApiConfig} from './core/models/IPGeolocationApiConfig';

--- a/universal-login-ops/src/dev/startDevelopment.ts
+++ b/universal-login-ops/src/dev/startDevelopment.ts
@@ -71,7 +71,11 @@ function getRelayerConfig(jsonRpcUrl: string, wallet: Wallet, walletContractAddr
       }
     },
     database: databaseConfig,
-    maxGasLimit: 500000
+    maxGasLimit: 500000,
+    ipGeolocationApi: {
+      baseUrl: 'http://api.ipstack.com',
+      accessKey: '52e66f1c79bb597131fd0c133704ee03',
+    }
   };
 }
 

--- a/universal-login-react/src/config/types.ts
+++ b/universal-login-react/src/config/types.ts
@@ -1,12 +1,9 @@
+import {IPGeolocationApiConfig} from '@universal-login/commons';
+
 export interface Config {
   domains: string[];
   relayerUrl: string;
   jsonRpcUrl: string;
   tokens: string[];
   ipGeolocationApi: IPGeolocationApiConfig;
-}
-
-export interface IPGeolocationApiConfig {
-  baseUrl: string;
-  accessKey: string;
 }

--- a/universal-login-relayer/lib/config/config.prod.ts
+++ b/universal-login-relayer/lib/config/config.prod.ts
@@ -49,7 +49,11 @@ export const config: Config =  Object.freeze({
       directory: path.join(__dirname, '../integration/sql/migrations'),
     }
   },
-  maxGasLimit: 500000
+  maxGasLimit: 500000,
+  ipGeolocationApi: {
+    baseUrl: 'http://api.ipstack.com',
+    accessKey: '52e66f1c79bb597131fd0c133704ee03',
+  }
 });
 
 export default config;

--- a/universal-login-relayer/lib/config/config.test.ts
+++ b/universal-login-relayer/lib/config/config.test.ts
@@ -47,7 +47,11 @@ export const config: Config =  Object.freeze({
       directory: path.join(__dirname, '../integration/sql/migrations'),
     }
   },
-  maxGasLimit: 500000
+  maxGasLimit: 500000,
+  ipGeolocationApi: {
+    baseUrl: 'http://api.ipstack.com',
+    accessKey: '52e66f1c79bb597131fd0c133704ee03',
+  }
 });
 
 export default config;

--- a/universal-login-relayer/lib/config/relayer.ts
+++ b/universal-login-relayer/lib/config/relayer.ts
@@ -1,4 +1,4 @@
-import {ContractWhiteList, SupportedToken, ChainSpec, LocalizationConfig, OnRampConfig} from '@universal-login/commons';
+import {ContractWhiteList, SupportedToken, ChainSpec, LocalizationConfig, OnRampConfig, IPGeolocationApiConfig} from '@universal-login/commons';
 import {KnexConfig} from './KnexConfig';
 
 export interface Config {
@@ -15,4 +15,5 @@ export interface Config {
   onRampProviders: OnRampConfig;
   database: KnexConfig;
   maxGasLimit: number;
+  ipGeolocationApi: IPGeolocationApiConfig;
 }

--- a/universal-login-relayer/lib/http/relayers/RelayerUnderTest.ts
+++ b/universal-login-relayer/lib/http/relayers/RelayerUnderTest.ts
@@ -84,6 +84,14 @@ export class RelayerUnderTest extends Relayer {
     return `http://127.0.0.1:${this.port}`;
   }
 
+  getConfig() {
+    return this.config;
+  }
+
+  getServer() {
+    return this.server;
+  }
+
   async clearDatabase() {
     return clearDatabase(this.database);
   }

--- a/universal-login-relayer/lib/http/routes/config.ts
+++ b/universal-login-relayer/lib/http/routes/config.ts
@@ -4,7 +4,7 @@ import {Config} from '../../config/relayer';
 import {PublicRelayerConfig} from '@universal-login/commons';
 
 export function getPublicConfig(config: Config): PublicRelayerConfig {
-  const {chainSpec, supportedTokens, factoryAddress, contractWhiteList, localization, onRampProviders, maxGasLimit} = config;
+  const {chainSpec, supportedTokens, factoryAddress, contractWhiteList, localization, onRampProviders, maxGasLimit, ipGeolocationApi} = config;
   return {
     chainSpec,
     supportedTokens,
@@ -12,7 +12,8 @@ export function getPublicConfig(config: Config): PublicRelayerConfig {
     contractWhiteList,
     localization,
     onRampProviders,
-    maxGasLimit
+    maxGasLimit,
+    ipGeolocationApi
   };
 }
 

--- a/universal-login-relayer/test/e2e/config.ts
+++ b/universal-login-relayer/test/e2e/config.ts
@@ -2,45 +2,49 @@ import chai, {expect} from 'chai';
 import chaiHttp from 'chai-http';
 import {startRelayer} from '../helpers/http';
 import {getPublicConfig} from '../../lib/http/routes/config';
+import {RelayerUnderTest} from '../../lib';
+import {PublicRelayerConfig} from '@universal-login/commons';
 
 chai.use(chaiHttp);
 
 describe('E2E: Relayer - Config routes', async () => {
-  let relayer;
+  let relayer: RelayerUnderTest;
 
   before(async () => {
     ({relayer} = await startRelayer());
   });
 
   it('should return public config', async () => {
-    const {supportedTokens, chainSpec, factoryAddress, contractWhiteList, localization, onRampProviders, maxGasLimit} = relayer.config;
-    const expectedConfig = {
+    const {supportedTokens, chainSpec, factoryAddress, contractWhiteList, localization, onRampProviders, maxGasLimit, ipGeolocationApi} = relayer.getConfig();
+    const expectedConfig: PublicRelayerConfig = {
       supportedTokens,
       chainSpec,
       factoryAddress,
       contractWhiteList,
       localization,
       onRampProviders,
-      maxGasLimit
+      maxGasLimit,
+      ipGeolocationApi
     };
-    const result = await chai.request(relayer.server)
+    const result = await chai.request(relayer.getServer())
       .get('/config');
     expect(result.body.config).to.be.deep.eq(expectedConfig);
   });
 
 
   it('getPublicConfig should return PublicConfig', () => {
-    const {supportedTokens, chainSpec, factoryAddress, contractWhiteList, localization, onRampProviders, maxGasLimit} = relayer.config;
-    const expectedConfig = {
+    const {supportedTokens, chainSpec, factoryAddress, contractWhiteList, localization, onRampProviders, maxGasLimit, ipGeolocationApi} = relayer.getConfig();
+    const expectedConfig: PublicRelayerConfig = {
       supportedTokens,
       chainSpec,
       factoryAddress,
       contractWhiteList,
       localization,
       onRampProviders,
-      maxGasLimit
+      maxGasLimit,
+      ipGeolocationApi
     };
-    const publicConfig = getPublicConfig(relayer.config);
+    const publicConfig = getPublicConfig(relayer.getConfig());
 
     expect(publicConfig).to.be.deep.eq(expectedConfig);
   });


### PR DESCRIPTION
Move IPGeolocationApiConfig type to commons

Rewrite Relayer config routes E2E tests to TypeScript and add necessary getters to RelayerUnderTest

Add IP-Geolocation Api config to Relayer public config and make config endpoint include it in its response

Add ipGeolocationApi config to getRelayerConfig method in startDevelopment script