### PR TITLE
SDK: Remove unnecessary getWalletContractAddress call

### DIFF
--- a/universal-login-commons/lib/core/utils/errors.ts
+++ b/universal-login-commons/lib/core/utils/errors.ts
@@ -16,3 +16,7 @@ export function ensure<T extends any[]>(condition: boolean, error: ErrorConstruc
 export function ensureNotNull<T extends any[]>(value: unknown | null, error: ErrorConstructor<T>, ...errorArgs: T) {
   return ensure(!!value, error, ...errorArgs);
 }
+
+export function ensureNotEmpty<T extends any[]>(object: object, error: ErrorConstructor<T>, ...errorArgs: T) {
+  return ensure((Object.entries(object).length !== 0), error, ...errorArgs);
+}

--- a/universal-login-commons/lib/index.ts
+++ b/universal-login-commons/lib/index.ts
@@ -23,7 +23,7 @@ export {getEmojiColor, getEmojiNumber, CATEGORIES, getBaseEmojiCode, getEmojiSet
 export {generateBackupCode} from './core/utils/generateBackupCode';
 export {getEmojiCodePoint} from './core/utils/emojiCodePoint';
 export {safeMultiply} from './core/utils/safeMultiply';
-export {ensure, ensureNotNull, onCritical} from './core/utils/errors';
+export {ensure, ensureNotNull, ensureNotEmpty, onCritical} from './core/utils/errors';
 export {computeCounterfactualAddress, computeContractAddress} from './core/utils/contracts/computeContractAddress';
 export {BalanceChecker} from './integration/ethereum/BalanceChecker';
 export {RequiredBalanceChecker} from './integration/ethereum/RequiredBalanceChecker';

--- a/universal-login-commons/test/core/handleError.ts
+++ b/universal-login-commons/test/core/handleError.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {ensure} from '../../lib';
+import {ensure, ensureNotEmpty, ensureNotNull} from '../../lib';
 
 describe('handleError', () => {
   describe('ensure', () => {
@@ -9,6 +9,30 @@ describe('handleError', () => {
 
     it('ensure true', () => {
       expect(() => ensure(true, Error, 'MyOwnArg')).to.not.throw(Error);
+    });
+  });
+
+  describe('ensureNotNull', () => {
+    it('null', () => {
+      expect(() => ensureNotNull(null, Error, 'null')).to.throw(Error, 'null');
+    });
+
+    it('null', () => {
+      expect(() => ensureNotNull(undefined, Error, 'undefined')).to.throw(Error, 'undefined');
+    });
+
+    it('not null', () => {
+      expect(() => ensureNotNull('test', Error, 'MyOwnArg')).to.not.throw(Error);
+    });
+  });
+
+  describe('ensureNotEmpty', () => {
+    it('empty object', () => {
+      expect(() => ensureNotEmpty({}, Error, 'Empty object')).to.throw(Error, 'Empty object');
+    });
+
+    it('not empty object', () => {
+      expect(() => ensureNotEmpty({test: 'test'}, Error, 'MyOwnArg')).to.not.throw(Error);
     });
   });
 });

--- a/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
+++ b/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
@@ -18,9 +18,9 @@ export interface TransferAmountProps {
 export const TransferAmount = ({deployedWallet, onSelectRecipientClick, updateTransferDetailsWith, currency, transferAmountClassName}: TransferAmountProps) => {
   const [tokenDetailsWithBalance, setTokenDetailsWithBalance] = useState<TokenDetailsWithBalance[]>([]);
   const [isAmountCorrect, setIsAmountCorrect] = useState(false);
-  const {sdk, name} = deployedWallet;
+  const {sdk, contractAddress} = deployedWallet;
 
-  useAsyncEffect(() => sdk.subscribeToBalances(name, setTokenDetailsWithBalance), []);
+  useAsyncEffect(() => sdk.subscribeToBalances(contractAddress, setTokenDetailsWithBalance), []);
   const balance = getBalanceOf(currency, tokenDetailsWithBalance);
 
   const validateAndUpdateTransferDetails = (amount: string) => {

--- a/universal-login-react/src/ui/UFlow/Funds.tsx
+++ b/universal-login-react/src/ui/UFlow/Funds.tsx
@@ -18,9 +18,9 @@ interface FundsProps {
 
 export const Funds = ({deployedWallet, onTopUpClick, onSendClick, className}: FundsProps) => {
   const [totalTokensValue, setTotalTokensValue] = useState<CurrencyToValue>({} as CurrencyToValue);
-  const {sdk, contractAddress, name} = deployedWallet;
+  const {sdk, contractAddress} = deployedWallet;
 
-  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(name, setTotalTokensValue), []);
+  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(contractAddress, setTotalTokensValue), []);
 
   return (
     <div className="universal-login-funds">

--- a/universal-login-react/src/ui/commons/Assets.tsx
+++ b/universal-login-react/src/ui/commons/Assets.tsx
@@ -19,9 +19,9 @@ const iconForToken = (symbol: string) => symbol === 'ETH' ? ethIcon : daiIcon;
 
 export const Assets = ({deployedWallet, className}: AssetsProps) => {
   const [tokenDetailsWithBalance, setTokenDetailsWithBalance] = useState<TokenDetailsWithBalance[]>([]);
-  const {sdk, name} = deployedWallet;
+  const {sdk, contractAddress} = deployedWallet;
 
-  useAsyncEffect(() => sdk.subscribeToBalances(name, setTokenDetailsWithBalance), []);
+  useAsyncEffect(() => sdk.subscribeToBalances(contractAddress, setTokenDetailsWithBalance), []);
 
   return (
     <div className="universal-login-assets">

--- a/universal-login-sdk/lib/api/DeployedWallet.ts
+++ b/universal-login-sdk/lib/api/DeployedWallet.ts
@@ -103,6 +103,6 @@ export class DeployedWallet implements ApplicationWallet {
   }
 
   subscribeToBalances(callback: OnBalanceChange) {
-    return this.sdk.subscribeToBalances(this.name, callback);
+    return this.sdk.subscribeToBalances(this.contractAddress, callback);
   }
 }

--- a/universal-login-sdk/lib/api/sdk.ts
+++ b/universal-login-sdk/lib/api/sdk.ts
@@ -1,6 +1,6 @@
 import {utils, Contract, providers} from 'ethers';
 import WalletContract from '@universal-login/contracts/build/Wallet.json';
-import {TokensValueConverter, TokenDetailsService, Notification, generateCode, addCodesToNotifications, resolveName, Message, ensureNotNull, PublicRelayerConfig, createKeyPair, signRelayerRequest, ensure, BalanceChecker, deepMerge, DeepPartial, SignedMessage} from '@universal-login/commons';
+import {TokensValueConverter, TokenDetailsService, Notification, generateCode, addCodesToNotifications, resolveName, Message, ensureNotNull, PublicRelayerConfig, createKeyPair, signRelayerRequest, ensure, BalanceChecker, deepMerge, DeepPartial, SignedMessage, ensureNotEmpty} from '@universal-login/commons';
 import AuthorisationsObserver from '../core/observers/AuthorisationsObserver';
 import BlockchainObserver from '../core/observers/BlockchainObserver';
 import {RelayerApi} from '../integration/http/RelayerApi';
@@ -97,23 +97,22 @@ class UniversalLoginSDK {
     return this.relayerConfig;
   }
 
-  async fetchBalanceObserver(ensName: string) {
+  async fetchBalanceObserver(contractAddress: string) {
     if (this.balanceObserver) {
       return;
     }
-    const walletContractAddress = await this.getWalletContractAddress(ensName);
-    ensureNotNull(walletContractAddress, InvalidContract);
-    ensureNotNull(this.relayerConfig, MissingConfiguration);
+    ensureNotNull(contractAddress, InvalidContract);
+    ensureNotEmpty(this.sdkConfig, MissingConfiguration);
 
     await this.tokensDetailsStore.fetchTokensDetails();
-    this.balanceObserver = new BalanceObserver(this.balanceChecker, walletContractAddress, this.tokensDetailsStore);
+    this.balanceObserver = new BalanceObserver(this.balanceChecker, contractAddress, this.tokensDetailsStore);
   }
 
-  async fetchAggregateBalanceObserver(ensName: string) {
+  async fetchAggregateBalanceObserver(contractAddress: string) {
     if (this.aggregateBalanceObserver) {
       return;
     }
-    await this.fetchBalanceObserver(ensName);
+    await this.fetchBalanceObserver(contractAddress);
     this.aggregateBalanceObserver = new AggregateBalanceObserver(this.balanceObserver!, this.priceObserver, this.tokensValueConverter);
   }
 
@@ -211,13 +210,13 @@ class UniversalLoginSDK {
     return this.blockchainObserver.subscribe(eventType, filter, callback);
   }
 
-  async subscribeToBalances(ensName: string, callback: OnBalanceChange) {
-    await this.fetchBalanceObserver(ensName);
+  async subscribeToBalances(contractAddress: string, callback: OnBalanceChange) {
+    await this.fetchBalanceObserver(contractAddress);
     return this.balanceObserver!.subscribe(callback);
   }
 
-  async subscribeToAggregatedBalance(ensName: string, callback: OnAggregatedBalanceChange) {
-    await this.fetchAggregateBalanceObserver(ensName);
+  async subscribeToAggregatedBalance(contractAddress: string, callback: OnAggregatedBalanceChange) {
+    await this.fetchAggregateBalanceObserver(contractAddress);
     return this.aggregateBalanceObserver!.subscribe(callback);
   }
 

--- a/universal-login-sdk/test/e2e/BalanceObserver.ts
+++ b/universal-login-sdk/test/e2e/BalanceObserver.ts
@@ -12,18 +12,17 @@ const loadFixture = createFixtureLoader();
 describe('E2E: BalanceObserver', () => {
   let sdk: UniversalLoginSDK;
   let relayer: RelayerUnderTest;
-  let ensName: string;
   let wallet: Wallet;
   let contractAddress: string;
 
   beforeEach(async () => {
-    ({sdk, relayer, ensName, wallet, contractAddress} = await loadFixture(basicSDK));
+    ({sdk, relayer, wallet, contractAddress} = await loadFixture(basicSDK));
   });
 
   it('1 subscription', async () => {
     const callback = sinon.spy();
 
-    const unsubscribe = await sdk.subscribeToBalances(ensName, callback);
+    const unsubscribe = await sdk.subscribeToBalances(contractAddress, callback);
     await waitUntil(() => !!callback.firstCall);
     unsubscribe();
 
@@ -33,7 +32,7 @@ describe('E2E: BalanceObserver', () => {
   it('1 subscription - balance changed', async () => {
     const callback = sinon.spy();
 
-    const unsubscribe = await sdk.subscribeToBalances(ensName, callback);
+    const unsubscribe = await sdk.subscribeToBalances(contractAddress, callback);
     await waitUntil(() => !!callback.firstCall);
 
     await wallet.sendTransaction({to: contractAddress, value: utils.parseEther('0.5')});
@@ -47,10 +46,10 @@ describe('E2E: BalanceObserver', () => {
     const callback1 = sinon.spy();
     const callback2 = sinon.spy();
 
-    const unsubscribe1 = await sdk.subscribeToBalances(ensName, callback1);
+    const unsubscribe1 = await sdk.subscribeToBalances(contractAddress, callback1);
     await waitUntil(() => !!callback1.firstCall);
 
-    const unsubscribe2 = await sdk.subscribeToBalances(ensName, callback2);
+    const unsubscribe2 = await sdk.subscribeToBalances(contractAddress, callback2);
     await waitUntil(() => !!callback2.firstCall);
 
     unsubscribe1();

--- a/universal-login-wallet/src/ui/react/Home/Balance.tsx
+++ b/universal-login-wallet/src/ui/react/Home/Balance.tsx
@@ -11,7 +11,7 @@ const Balance = () => {
   const [totalBalance, setTotalBalance] = useState<number>(0);
   const {sdk, walletPresenter} = useServices();
 
-  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(walletPresenter.getName(), (totalBalances: CurrencyToValue) => setTotalBalance(totalBalances['USD'])), []);
+  useAsyncEffect(() => sdk.subscribeToAggregatedBalance(walletPresenter.getContractAddress(), (totalBalances: CurrencyToValue) => setTotalBalance(totalBalances['USD'])), []);
 
   return(
     <section className="balance">


### PR DESCRIPTION
# Summary
Remove getWalletContractAddress call in fetchBalanceObserver due to the possibility to pass the contract address instead of ens name.

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

