### PR TITLE
React: Reduce props passed in top-up components

### DIFF
--- a/universal-login-react/src/App.tsx
+++ b/universal-login-react/src/App.tsx
@@ -1,17 +1,17 @@
 import React, {useState} from 'react';
-import {Route, Switch, BrowserRouter} from 'react-router-dom';
+import {BrowserRouter, Route, Switch} from 'react-router-dom';
 import {Wallet} from 'ethers';
 import {NavigationColumn} from './ui/commons/NavigationColumn';
 import {WalletSelector} from './ui/WalletSelector/WalletSelector';
 import {EmojiForm} from './ui/Notifications/EmojiForm';
-import {generateCode, ApplicationWallet, TEST_CONTRACT_ADDRESS, TEST_PRIVATE_KEY} from '@universal-login/commons';
+import {ApplicationWallet, generateCode, TEST_CONTRACT_ADDRESS, TEST_PRIVATE_KEY} from '@universal-login/commons';
 import {EmojiPanel} from './ui/WalletSelector/EmojiPanel';
 import {Settings} from './ui/Settings/Settings';
 import {Onboarding} from './ui/Onboarding/Onboarding';
 import {useServices} from './core/services/useServices';
 import Modals from './ui/Modals/Modals';
 import {createModalService} from './core/services/createModalService';
-import {ReactModalType, ReactModalContext, ReactModalProps, TopUpProps} from './core/models/ReactModalContext';
+import {ReactModalContext, ReactModalProps, ReactModalType, TopUpProps} from './core/models/ReactModalContext';
 import {useAsync} from './ui/hooks/useAsync';
 import {LogoButton} from './ui/UFlow/LogoButton';
 import {CreateRandomInstance} from './ui/commons/CreateRandomInstance';
@@ -137,8 +137,6 @@ export const App = () => {
                 }
                 const topUpProps: TopUpProps = {
                   contractAddress: Wallet.createRandom().address,
-                  onRampConfig: relayerConfig!.onRampProviders,
-                  ipGeolocationApiConfig: relayerConfig!.ipGeolocationApi,
                   onGasParametersChanged: console.log,
                   sdk
                 };

--- a/universal-login-react/src/core/models/ReactModalContext.ts
+++ b/universal-login-react/src/core/models/ReactModalContext.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import {IPGeolocationApiConfig, OnGasParametersChanged, OnRampConfig} from '@universal-login/commons';
+import {OnGasParametersChanged} from '@universal-login/commons';
 import {IModalService} from '../services/createModalService';
 import UniversalLoginSDK from '@universal-login/sdk';
 
@@ -10,8 +10,6 @@ export type ReactModalProps = TopUpProps;
 export type TopUpProps = {
   sdk: UniversalLoginSDK
   contractAddress: string;
-  onRampConfig: OnRampConfig;
-  ipGeolocationApiConfig: IPGeolocationApiConfig;
   onGasParametersChanged: OnGasParametersChanged;
 };
 

--- a/universal-login-react/src/ui/Onboarding/Onboarding.tsx
+++ b/universal-login-react/src/ui/Onboarding/Onboarding.tsx
@@ -1,10 +1,10 @@
 import React, {useState} from 'react';
-import UniversalLoginSDK, {WalletService, FutureWallet} from '@universal-login/sdk';
+import UniversalLoginSDK, {FutureWallet, WalletService} from '@universal-login/sdk';
 import {WalletSelector} from '../WalletSelector/WalletSelector';
 import Modals from '../Modals/Modals';
 import {ApplicationWallet, GasParameters, INITIAL_GAS_PARAMETERS} from '@universal-login/commons';
 import {getStyleForTopLevelComponent} from '../../core/utils/getStyleForTopLevelComponent';
-import {ReactModalContext, ReactModalType, ReactModalProps, TopUpProps} from '../../core/models/ReactModalContext';
+import {ReactModalContext, ReactModalProps, ReactModalType, TopUpProps} from '../../core/models/ReactModalContext';
 import {createModalService} from '../../core/services/createModalService';
 
 export interface OnboardingWalletService {
@@ -33,11 +33,8 @@ export const Onboarding = (props: OnboardingProps) => {
   const onCreateClick = async (ensName: string) => {
     let gasParameters = INITIAL_GAS_PARAMETERS;
     const {deploy, waitForBalance, contractAddress} = await walletService.createFutureWallet();
-    const relayerConfig = await props.sdk.getRelayerConfig();
     const topUpProps: TopUpProps = {
       contractAddress,
-      onRampConfig: relayerConfig!.onRampProviders,
-      ipGeolocationApiConfig: relayerConfig!.ipGeolocationApi,
       onGasParametersChanged: (parameters: GasParameters) => { gasParameters = parameters; },
       sdk: props.sdk
     };

--- a/universal-login-react/src/ui/TopUp/ChooseTopUpMethod.tsx
+++ b/universal-login-react/src/ui/TopUp/ChooseTopUpMethod.tsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import UniversalLoginSDK from '@universal-login/sdk';
 import './../styles/topup.css';
 import './../styles/topUpModalDefaults.css';
 import daiIcon from './../assets/topUp/dai.svg';
@@ -11,17 +12,16 @@ import {TopUpWithCrypto} from './TopUpWithCrypto';
 import {getStyleForTopLevelComponent} from '../../core/utils/getStyleForTopLevelComponent';
 import {LogoColor} from './Fiat/FiatPaymentMethods';
 import {TopUpProvider} from '../../core/models/TopUpProvider';
-import {IPGeolocationApiConfig} from '@universal-login/commons';
 
 export interface ChooseTopUpMethodProps {
+  sdk: UniversalLoginSDK;
   contractAddress: string;
   onPayClick: (topUpProvider: TopUpProvider, amount: string) => void;
-  ipGeolocationApiConfig: IPGeolocationApiConfig;
   topUpClassName?: string;
   logoColor?: LogoColor;
 }
 
-export const ChooseTopUpMethod = ({contractAddress, onPayClick, ipGeolocationApiConfig, topUpClassName, logoColor}: ChooseTopUpMethodProps) => {
+export const ChooseTopUpMethod = ({sdk, contractAddress, onPayClick, topUpClassName, logoColor}: ChooseTopUpMethodProps) => {
   const [topUpMethod, setTopUpMethod] = useState('');
 
   const methodSelectedClassName = topUpMethod !== '' ? 'method-selected' : '';
@@ -67,12 +67,7 @@ export const ChooseTopUpMethod = ({contractAddress, onPayClick, ipGeolocationApi
           <div className="top-up-body">
             <div className="top-up-body-inner">
               {topUpMethod === 'crypto' && <TopUpWithCrypto contractAddress={contractAddress}/>}
-              {topUpMethod === 'fiat' &&
-              <TopUpWithFiat
-                  onPayClick={onPayClick}
-                  logoColor={logoColor}
-                  ipGeolocationApiConfig={ipGeolocationApiConfig}
-              />}
+              {topUpMethod === 'fiat' && <TopUpWithFiat sdk={sdk} onPayClick={onPayClick} logoColor={logoColor}/>}
             </div>
           </div>
         </div>

--- a/universal-login-react/src/ui/TopUp/TopUp.tsx
+++ b/universal-login-react/src/ui/TopUp/TopUp.tsx
@@ -1,11 +1,5 @@
 import React, {useState} from 'react';
-import {
-  DEPLOY_GAS_LIMIT,
-  IPGeolocationApiConfig,
-  OnGasParametersChanged,
-  OnRampConfig,
-  stringToEther
-} from '@universal-login/commons';
+import {DEPLOY_GAS_LIMIT, OnGasParametersChanged, PublicRelayerConfig, stringToEther} from '@universal-login/commons';
 import UniversalLoginSDK from '@universal-login/sdk';
 import {Safello} from '../../integration/Safello';
 import {Ramp} from '../../integration/Ramp';
@@ -16,6 +10,7 @@ import {LogoColor} from './Fiat/FiatPaymentMethods';
 import {TopUpProvider} from '../../core/models/TopUpProvider';
 import {toTopUpComponentType} from '../../core/utils/toTopUpComponentType';
 import {GasPrice} from '../commons/GasPrice';
+import {useAsync} from '../../ui/hooks/useAsync';
 import {FooterSection} from '../commons/FooterSection';
 
 interface TopUpProps {
@@ -23,8 +18,6 @@ interface TopUpProps {
   contractAddress: string;
   onGasParametersChanged: OnGasParametersChanged;
   startModal?: TopUpComponentType;
-  onRampConfig: OnRampConfig;
-  ipGeolocationApiConfig: IPGeolocationApiConfig;
   topUpClassName?: string;
   modalClassName?: string;
   hideModal?: () => void;
@@ -32,79 +25,70 @@ interface TopUpProps {
   logoColor?: LogoColor;
 }
 
-export const TopUp = ({sdk, onGasParametersChanged, contractAddress, startModal, onRampConfig, ipGeolocationApiConfig, modalClassName, hideModal, isModal, topUpClassName, logoColor}: TopUpProps) => {
+export const TopUp = ({sdk, onGasParametersChanged, contractAddress, startModal, modalClassName, hideModal, isModal, topUpClassName, logoColor}: TopUpProps) => {
   const [modal, setModal] = useState<TopUpComponentType>(startModal || TopUpComponentType.choose);
   const [amount, setAmount] = useState('');
+
+  const [relayerConfig] = useAsync<PublicRelayerConfig>(() => sdk.getRelayerConfig(), []);
 
   const onPayClick = (provider: TopUpProvider, amount: string) => {
     setModal(toTopUpComponentType(provider));
     setAmount(amount);
   };
 
-  if (modal === TopUpComponentType.choose) {
-    if (isModal) {
-      return (
-        <ModalWrapper modalClassName={modalClassName} hideModal={hideModal}>
-          <ChooseTopUpMethod
-            contractAddress={contractAddress}
-            onPayClick={onPayClick}
-            ipGeolocationApiConfig={ipGeolocationApiConfig}
-            topUpClassName={topUpClassName}
-            logoColor={logoColor}
-          />
-          <FooterSection className={topUpClassName}>
-            <GasPrice
-              isDeployed={false}
-              sdk={sdk}
-              onGasParametersChanged={onGasParametersChanged}
-              gasLimit={DEPLOY_GAS_LIMIT}
-              className={topUpClassName}
-            />
-          </FooterSection>
-        </ModalWrapper>
-      );
-    }
-    return (
-      <>
-        <ChooseTopUpMethod
-          contractAddress={contractAddress}
-          onPayClick={onPayClick}
-          ipGeolocationApiConfig={ipGeolocationApiConfig}
-          topUpClassName={topUpClassName}
-          logoColor={logoColor}
+  const getTopUpMethodChooser = () => (
+    <>
+      <ChooseTopUpMethod
+        sdk={sdk}
+        contractAddress={contractAddress}
+        onPayClick={onPayClick}
+        topUpClassName={topUpClassName}
+        logoColor={logoColor}
+      />
+      <FooterSection className={topUpClassName}>
+        <GasPrice
+          isDeployed={false}
+          sdk={sdk}
+          onGasParametersChanged={onGasParametersChanged}
+          gasLimit={DEPLOY_GAS_LIMIT}
+          className={topUpClassName}
         />
-        <FooterSection className={topUpClassName}>
-          <GasPrice
-            isDeployed={false}
-            sdk={sdk}
-            onGasParametersChanged={onGasParametersChanged}
-            gasLimit={DEPLOY_GAS_LIMIT}
-            className={topUpClassName}
-          />
-        </FooterSection>
-      </>
-    );
+      </FooterSection>
+    </>
+  );
+
+  if (!relayerConfig) {
+    return <div>Loading...</div>;
+
+  } else if (modal === TopUpComponentType.choose) {
+    if (isModal) {
+      return <ModalWrapper modalClassName={modalClassName} hideModal={hideModal}>{getTopUpMethodChooser()}</ModalWrapper>;
+    }
+    return getTopUpMethodChooser();
+
   } else if (modal === TopUpComponentType.safello) {
     return (
       <ModalWrapper modalClassName={modalClassName} hideModal={() => setModal(TopUpComponentType.choose)}>
         <Safello
           localizationConfig={{} as any}
-          safelloConfig={onRampConfig.safello}
+          safelloConfig={relayerConfig.onRampProviders.safello}
           contractAddress={contractAddress}
           crypto="eth"
         />
       </ModalWrapper>
     );
+
   } else if (modal === TopUpComponentType.ramp) {
     return (
       <Ramp
         address={contractAddress}
         amount={stringToEther(amount)}
         currency={'ETH'}
-        config={onRampConfig.ramp}
+        config={relayerConfig.onRampProviders.ramp}
         onClose={() => setModal(TopUpComponentType.choose)}
       />
     );
+
   } else {
     throw new Error(`Unsupported type: ${modal}`);
   }

--- a/universal-login-react/src/ui/UFlow/UDashboard.tsx
+++ b/universal-login-react/src/ui/UFlow/UDashboard.tsx
@@ -4,7 +4,6 @@ import {UHeader} from './UHeader';
 import {Funds} from './Funds';
 import {asTransferDetails, TransferDetails} from '@universal-login/commons';
 import {DeployedWallet, TransferService, setBetaNotice} from '@universal-login/sdk';
-import {useAsync} from '../hooks/useAsync';
 import logoIcon from '../assets/icons/U.svg';
 import {DashboardContentType} from '../../core/models/ReactUDashboardContentType';
 import './../styles/udashboard.sass';
@@ -35,7 +34,6 @@ export const UDashboard = ({deployedWallet}: UDashboardProps) => {
   const [transferDetails, setTransferDetails] = useState<Partial<TransferDetails>>({currency: sdk.tokensDetailsStore.tokensDetails[0].symbol});
   const [dashboardContent, setDashboardContent] = useState<DashboardContentType>('none');
   const [dashboardVisibility, setDashboardVisibility] = useState(false);
-  const [relayerConfig] = useAsync(() => sdk.getRelayerConfig(), []);
 
   const [notice, setNotice] = useState('');
   useEffect(() => {
@@ -81,8 +79,6 @@ export const UDashboard = ({deployedWallet}: UDashboardProps) => {
             onGasParametersChanged={() => {}}
             hideModal={() => setDashboardVisibility(false)}
             contractAddress={contractAddress}
-            onRampConfig={relayerConfig!.onRampProviders}
-            ipGeolocationApiConfig={relayerConfig!.ipGeolocationApi}
           />
         );
       case 'transferAmount':

--- a/universal-login-sdk/lib/api/sdk.ts
+++ b/universal-login-sdk/lib/api/sdk.ts
@@ -1,18 +1,36 @@
-import {utils, Contract, providers} from 'ethers';
+import {Contract, providers, utils} from 'ethers';
 import WalletContract from '@universal-login/contracts/build/Wallet.json';
-import {TokensValueConverter, TokenDetailsService, Notification, generateCode, addCodesToNotifications, resolveName, Message, ensureNotNull, PublicRelayerConfig, createKeyPair, signRelayerRequest, ensure, BalanceChecker, deepMerge, DeepPartial, SignedMessage, ensureNotEmpty} from '@universal-login/commons';
+import {
+  addCodesToNotifications,
+  BalanceChecker,
+  createKeyPair,
+  deepMerge,
+  DeepPartial,
+  ensure,
+  ensureNotEmpty,
+  ensureNotNull,
+  generateCode,
+  Message,
+  Notification,
+  PublicRelayerConfig,
+  resolveName,
+  SignedMessage,
+  signRelayerRequest,
+  TokenDetailsService,
+  TokensValueConverter
+} from '@universal-login/commons';
 import AuthorisationsObserver from '../core/observers/AuthorisationsObserver';
 import BlockchainObserver from '../core/observers/BlockchainObserver';
 import {RelayerApi} from '../integration/http/RelayerApi';
 import {BlockchainService} from '../integration/ethereum/BlockchainService';
-import {MissingConfiguration, InvalidEvent, InvalidContract, InvalidGasLimit} from '../core/utils/errors';
+import {InvalidContract, InvalidEvent, InvalidGasLimit, MissingConfiguration} from '../core/utils/errors';
 import {FutureWalletFactory} from './FutureWalletFactory';
-import {ExecutionFactory, Execution} from '../core/services/ExecutionFactory';
+import {Execution, ExecutionFactory} from '../core/services/ExecutionFactory';
 import {BalanceObserver, OnBalanceChange} from '../core/observers/BalanceObserver';
 import {SdkConfigDefault} from '../config/SdkConfigDefault';
 import {SdkConfig} from '../config/SdkConfig';
 import {AggregateBalanceObserver, OnAggregatedBalanceChange} from '../core/observers/AggregateBalanceObserver';
-import {PriceObserver, OnTokenPricesChange} from '../core/observers/PriceObserver';
+import {OnTokenPricesChange, PriceObserver} from '../core/observers/PriceObserver';
 import {TokensDetailsStore} from '../core/services/TokensDetailsStore';
 import {messageToSignedMessage} from '@universal-login/contracts';
 import {ensureSufficientGas} from '../core/utils/validation';
@@ -100,7 +118,7 @@ class UniversalLoginSDK {
     return this.relayerApi.getStatus(messageHash);
   }
 
-  async getRelayerConfig() {
+  async getRelayerConfig(): Promise<PublicRelayerConfig> {
     this.relayerConfig = this.relayerConfig || (await this.relayerApi.getConfig()).config;
     return this.relayerConfig;
   }

--- a/universal-login-sdk/lib/integration/http/RelayerApi.ts
+++ b/universal-login-sdk/lib/integration/http/RelayerApi.ts
@@ -1,13 +1,13 @@
-import {RelayerRequest, http, HttpFunction} from '@universal-login/commons';
+import {http, HttpFunction, PublicRelayerConfig, RelayerRequest} from '@universal-login/commons';
 import {fetch} from './fetch';
 
 export class RelayerApi {
-  private http: HttpFunction;
+  private readonly http: HttpFunction;
   constructor(relayerUrl: string, private applicationName: string) {
     this.http = http(fetch)(relayerUrl);
   }
 
-  async getConfig() {
+  async getConfig(): Promise<{config: PublicRelayerConfig}> {
     return this.http('GET', '/config');
   }
 

--- a/universal-login-wallet/src/ui/react/CreateAccount/CreateAccount.tsx
+++ b/universal-login-wallet/src/ui/react/CreateAccount/CreateAccount.tsx
@@ -3,10 +3,15 @@ import vaultImage from './../../assets/illustrations/vault.png';
 import vaultImage2x from './../../assets/illustrations/vault@2x.png';
 import {useServices, useWalletConfig} from '../../hooks';
 import {WalletSelector} from '@universal-login/react';
-import {WalletSuggestionAction, ETHER_NATIVE_TOKEN, GasParameters, INITIAL_GAS_PARAMETERS} from '@universal-login/commons';
+import {
+  ETHER_NATIVE_TOKEN,
+  GasParameters,
+  INITIAL_GAS_PARAMETERS,
+  WalletSuggestionAction
+} from '@universal-login/commons';
 import Modal from '../Modals/Modal';
 import {Link} from 'react-router-dom';
-import {WalletModalContext} from '../../../core/entities/WalletModalContext';
+import {TopUpModalProps, WalletModalContext} from '../../../core/entities/WalletModalContext';
 
 export const CreateAccount = () => {
   const modalService = useContext(WalletModalContext);
@@ -17,9 +22,10 @@ export const CreateAccount = () => {
   const onCreateClick = async (name: string) => {
     let gasParameters = INITIAL_GAS_PARAMETERS;
     const {deploy, waitForBalance} = await walletService.createFutureWallet();
-    modalService.showModal('topUpAccount', {
+    const topUpProps: TopUpModalProps = {
       onGasParametersChanged: (parameters: GasParameters) => { gasParameters = parameters; }
-    });
+    };
+    modalService.showModal('topUpAccount', topUpProps);
     await waitForBalance();
     modalService.showModal('waitingForDeploy');
     await deploy(name, gasParameters.gasPrice.toString(), ETHER_NATIVE_TOKEN.address);

--- a/universal-login-wallet/src/ui/react/Modals/Modal.tsx
+++ b/universal-login-wallet/src/ui/react/Modals/Modal.tsx
@@ -2,12 +2,12 @@ import React, {useContext} from 'react';
 import ModalWrapperWithoutClose from './ModalWrapper';
 import ModalTransfer from './Transfer/ModalTransfer';
 import ModalRequest from './ModalRequest';
-import {useServices, useRelayerConfig} from '../../hooks';
+import {useRelayerConfig, useServices} from '../../hooks';
 import ModalWrapperClosable from './ModalWrapperClosable';
 import ModalWaitingFor from './ModalWaitingFor';
-import {Safello, TopUp, ModalWrapper} from '@universal-login/react';
+import {ModalWrapper, Safello, TopUp} from '@universal-login/react';
 import {ModalTxnSuccess} from './ModalTxnSuccess';
-import {WalletModalContext, TopUpModalProps} from '../../../core/entities/WalletModalContext';
+import {TopUpModalProps, WalletModalContext} from '../../../core/entities/WalletModalContext';
 import {hideTopUpModal} from '../../../core/utils/hideTopUpModal';
 
 const Modal = () => {
@@ -35,8 +35,6 @@ const Modal = () => {
           {...modalService.modalProps as TopUpModalProps}
           modalClassName="topup-modal-wrapper"
           topUpClassName="jarvis-styles"
-          onRampConfig={relayerConfig!.onRampProviders}
-          ipGeolocationApiConfig={relayerConfig!.ipGeolocationApi}
           contractAddress={walletPresenter.getContractAddress()}
           isModal
           logoColor="black"


### PR DESCRIPTION
Remove configs from TopUp component props

Remove configs from TopUpProps Modal Context type

Add return types to getConfig methods in sdk

Refactor TopUp component to use relayerConfig fetched using useAsync

Pass UL sdk down to TopUpWithFiat component instead of ipGeolocationApiConfig

Add readonly constraint to never changed http field in RelayerApi class

Add type to props object passed to modalService in Wallet