### PR TITLE
React: Cast to number amount and balance in comparison

### DIFF
--- a/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
+++ b/universal-login-react/src/ui/Transfer/Amount/TransferAmount.tsx
@@ -25,7 +25,7 @@ export const TransferAmount = ({deployedWallet, onSelectRecipientClick, updateTr
 
   const validateAndUpdateTransferDetails = (amount: string) => {
     if (balance && amount) {
-      setIsAmountCorrect(amount <= balance);
+      setIsAmountCorrect(Number(amount) <= Number(balance));
     } else {
       setIsAmountCorrect(false);
     }


### PR DESCRIPTION
# Summary
Cast amount and balance to a number before comparison because strings could provide errors.

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

