### PR TITLE
Improve passing relayerConfig to WaitingFor

### DIFF
--- a/universal-login-react/src/core/models/ReactModalContext.ts
+++ b/universal-login-react/src/core/models/ReactModalContext.ts
@@ -2,10 +2,11 @@ import React from 'react';
 import {OnGasParametersChanged} from '@universal-login/commons';
 import {IModalService} from '../services/createModalService';
 import UniversalLoginSDK from '@universal-login/sdk';
+import {WaitingForProps} from '../../ui/commons/WaitingFor';
 
-export type ReactModalType = 'topUpAccount' | 'topUp' | 'address' | 'waitingForDeploy' | 'waitingForTransfer' | 'safello';
+export type ReactModalType = 'topUpAccount' | 'topUp' | 'address' | 'waitingFor' | 'safello';
 
-export type ReactModalProps = TopUpProps;
+export type ReactModalProps = TopUpProps | WaitingForProps;
 
 export type TopUpProps = {
   sdk: UniversalLoginSDK

--- a/universal-login-react/src/ui/Modals/Modals.tsx
+++ b/universal-login-react/src/ui/Modals/Modals.tsx
@@ -1,10 +1,8 @@
 import React, {useContext} from 'react';
 import {ModalWrapper} from './ModalWrapper';
-import {WaitingFor} from '../commons/WaitingFor';
+import {WaitingFor, WaitingForProps} from '../commons/WaitingFor';
 import {ReactModalContext, TopUpProps} from '../../core/models/ReactModalContext';
 import {TopUp} from '../TopUp/TopUp';
-import {useAsync} from '../hooks/useAsync';
-import {useServices} from '../../core/services/useServices';
 
 export interface ModalsProps {
   modalClassName?: string;
@@ -12,8 +10,6 @@ export interface ModalsProps {
 
 const Modals = ({modalClassName}: ModalsProps) => {
   const modalService = useContext(ReactModalContext);
-  const {sdk} = useServices();
-  const [relayerConfig] = useAsync(async () => sdk.getRelayerConfig(), []);
 
   switch (modalService.modalName) {
     case 'topUpAccount':
@@ -25,20 +21,10 @@ const Modals = ({modalClassName}: ModalsProps) => {
           isModal
         />
       );
-    case 'waitingForDeploy':
+    case 'waitingFor':
       return (
         <ModalWrapper modalPosition="center">
-          {relayerConfig ?
-            <WaitingFor {...modalService.modalProps} action={'Wallet creation'} chainName={relayerConfig!.chainSpec.name} transactionHash={'0xee9270ccdeb9fcb92b3ec509ba11ba2362ab32ba8f...'}/> :
-            '...'}
-        </ModalWrapper>
-      );
-    case 'topUp':
-      return (
-        <ModalWrapper modalPosition="center">
-          {relayerConfig ?
-            <WaitingFor {...modalService.modalProps} action={'Top up'} chainName={relayerConfig!.chainSpec.name} transactionHash={'0xee9270ccdeb9fcb92b3ec509ba11ba2362ab32ba8f...'}/> :
-            '...'}
+            <WaitingFor {...modalService.modalProps as WaitingForProps}/>
         </ModalWrapper>
       );
     default:

--- a/universal-login-react/src/ui/Onboarding/Onboarding.tsx
+++ b/universal-login-react/src/ui/Onboarding/Onboarding.tsx
@@ -33,7 +33,7 @@ export const Onboarding = (props: OnboardingProps) => {
   const onCreateClick = async (ensName: string) => {
     let gasParameters = INITIAL_GAS_PARAMETERS;
     const {deploy, waitForBalance, contractAddress} = await walletService.createFutureWallet();
-    await props.sdk.getRelayerConfig();
+    const relayerConfig = await props.sdk.getRelayerConfig();
     const topUpProps: TopUpProps = {
       contractAddress,
       onGasParametersChanged: (parameters: GasParameters) => { gasParameters = parameters; },
@@ -41,7 +41,11 @@ export const Onboarding = (props: OnboardingProps) => {
     };
     modalService.showModal('topUpAccount', topUpProps);
     await waitForBalance();
-    modalService.showModal('waitingForDeploy');
+    modalService.showModal('waitingFor', {
+      relayerConfig,
+      action: 'Wallet creation',
+      transactionHash: '0xee9270ccdeb9fcb92b3ec509ba11ba2362ab32ba8f...'}
+    );
     const wallet = await deploy(ensName, gasParameters.gasPrice.toString(), gasParameters.gasToken);
     walletService.setDeployed(ensName);
     modalService.hideModal();

--- a/universal-login-react/src/ui/UFlow/UDashboard.tsx
+++ b/universal-login-react/src/ui/UFlow/UDashboard.tsx
@@ -115,7 +115,7 @@ export const UDashboard = ({deployedWallet}: UDashboardProps) => {
         );
       case 'waitingForTransfer':
         return (
-          <WaitingFor action={'Transferring funds'} chainName={relayerConfig!.chainSpec.name} transactionHash={transactionHash}/>
+          relayerConfig ? <WaitingFor action={'Transferring funds'} relayerConfig={relayerConfig!} transactionHash={transactionHash}/> : '...'
         );
       case 'devices':
         return (

--- a/universal-login-react/src/ui/commons/WaitingFor.tsx
+++ b/universal-login-react/src/ui/commons/WaitingFor.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import {ProgressBar} from '../commons/ProgressBar';
 import {ExplorerLink} from '../commons/ExplorerLink';
 import '../styles/waitingFor.sass';
+import {PublicRelayerConfig} from '@universal-login/commons';
 
 export interface WaitingForProps {
   action: string;
-  chainName: string;
+  relayerConfig: PublicRelayerConfig;
   transactionHash?: string;
 }
 
-export const WaitingFor = ({action, chainName, transactionHash}: WaitingForProps) => {
+export const WaitingFor = ({action, relayerConfig, transactionHash}: WaitingForProps) => {
   return (
     <div className="universal-login-waiting-for">
       <div className="action-title-box">
@@ -19,7 +20,7 @@ export const WaitingFor = ({action, chainName, transactionHash}: WaitingForProps
         <div>
           <ProgressBar className="pending-bar"/>
           <h3 className="transaction-hash-title">Transaction hash</h3>
-          <ExplorerLink chainName={chainName} transactionHash={transactionHash} />
+          <ExplorerLink chainName={relayerConfig.chainSpec.name} transactionHash={transactionHash} />
         </div>
         <p className="info-text">It takes time to register your username and deploy your wallet. In order to do so, we need to create a transaction and wait until the Ethereum blockchain validates it...</p>
       </div>


### PR DESCRIPTION
# Summary
Pass relayerConfig to WaitingFor instead of getting it from sdk.

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

