### PR TITLE
Introduce deployment executor

### DIFF
--- a/universal-login-relayer/lib/http/relayers/Relayer.ts
+++ b/universal-login-relayer/lib/http/relayers/Relayer.ts
@@ -37,6 +37,7 @@ import IRepository from '../../core/services/messages/IRepository';
 import Deployment from '../../core/models/Deployment';
 import SQLRepository from '../../integration/sql/services/SQLRepository';
 import ExecutionWorker from '../../core/services/messages/ExecutionWorker';
+import DeploymentExecutor from '../../integration/ethereum/DeploymentExecutor';
 
 const defaultPort = '3311';
 
@@ -71,6 +72,7 @@ class Relayer {
   private messageExecutionValidator: IMessageValidator = {} as IMessageValidator;
   private executionWorker: ExecutionWorker = {} as ExecutionWorker;
   private messageExecutor: MessageExecutor = {} as MessageExecutor;
+  private deploymentExecutor: DeploymentExecutor = {} as DeploymentExecutor;
   private app: Application = {} as Application;
   protected server: Server = {} as Server;
   private walletDeployer: WalletDeployer = {} as WalletDeployer;
@@ -119,7 +121,8 @@ class Relayer {
     this.deploymentHandler = new DeploymentHandler(this.walletContractService, this.deploymentRepository, this.executionQueue);
     this.messageHandler = new MessageHandler(this.wallet, this.authorisationStore, this.devicesService, this.hooks, this.messageRepository, this.statusService, this.gasValidator, this.executionQueue);
     this.messageExecutor = new MessageExecutor(this.wallet, this.messageExecutionValidator, this.messageRepository, this.messageHandler.onTransactionMined.bind(this.messageHandler));
-    this.executionWorker = new ExecutionWorker([this.messageExecutor], this.executionQueue);
+    this.deploymentExecutor = new DeploymentExecutor(this.deploymentRepository);
+    this.executionWorker = new ExecutionWorker([this.messageExecutor, this.deploymentExecutor], this.executionQueue);
     this.app.use(bodyParser.json());
     this.app.use('/wallet', WalletRouter(this.deploymentHandler, this.messageHandler));
     this.app.use('/config', ConfigRouter(this.publicConfig));

--- a/universal-login-relayer/lib/integration/ethereum/DeploymentExecutor.ts
+++ b/universal-login-relayer/lib/integration/ethereum/DeploymentExecutor.ts
@@ -1,0 +1,39 @@
+import {providers} from 'ethers';
+import {QueueItem} from '../../core/models/QueueItem';
+import {IExecutor} from '../../core/services/execution/IExecutor';
+import Deployment from '../../core/models/Deployment';
+import IRepository from '../../core/services/messages/IRepository';
+import {TransactionHashNotFound} from '../../core/utils/errors';
+import {ensureNotNull} from '@universal-login/commons';
+
+export class DeploymentExecutor implements IExecutor<Deployment> {
+
+  constructor(
+    private deploymentRepository: IRepository<Deployment>,
+  ) {}
+
+  canExecute(item: QueueItem): boolean {
+    return item.type === 'Deployment';
+  }
+
+  async handleExecute(deploymentHash: string) {
+    try {
+      const deployment = await this.deploymentRepository.get(deploymentHash);
+      const transactionResponse = await this.execute(deployment);
+      const {hash, wait} = transactionResponse;
+      ensureNotNull(hash, TransactionHashNotFound);
+      await this.deploymentRepository.markAsPending(deploymentHash, hash!);
+      await wait();
+      await this.deploymentRepository.setState(deploymentHash, 'Success');
+    } catch (error) {
+      const errorMessage = `${error.name}: ${error.message}`;
+      await this.deploymentRepository.markAsError(deploymentHash, errorMessage);
+    }
+  }
+
+  async execute(deployment: Deployment): Promise<providers.TransactionResponse> {
+    return {hash: 'xyz', wait: async () => {}} as any;
+  }
+}
+
+export default DeploymentExecutor;

--- a/universal-login-relayer/test/unit/core/QueueService.ts
+++ b/universal-login-relayer/test/unit/core/QueueService.ts
@@ -9,6 +9,10 @@ import MessageMemoryRepository from '../../helpers/MessageMemoryRepository';
 import {createMessageItem} from '../../../lib/core/utils/messages/serialisation';
 import IMessageRepository from '../../../lib/core/services/messages/IMessagesRepository';
 import MessageExecutor from '../../../lib/integration/ethereum/MessageExecutor';
+import DeploymentExecutor from '../../../lib/integration/ethereum/DeploymentExecutor';
+import IRepository from '../../../lib/core/services/messages/IRepository';
+import MemoryRepository from '../../helpers/MemoryRepository';
+import Deployment from '../../../lib/core/models/Deployment';
 
 use(sinonChai);
 
@@ -16,7 +20,9 @@ describe('UNIT: Queue Service', async () => {
   let executionWorker: ExecutionWorker;
   let queueMemoryStore: QueueMemoryStore;
   let messageRepository: IMessageRepository;
+  let deploymentRepository: IRepository<Deployment>;
   let messageExecutor: MessageExecutor;
+  let deploymentExecutor: DeploymentExecutor;
   const wait = sinon.spy();
   const wallet: any = {
     sendTransaction: sinon.fake.returns({
@@ -34,8 +40,10 @@ describe('UNIT: Queue Service', async () => {
   beforeEach(async () => {
     queueMemoryStore = new QueueMemoryStore();
     messageRepository = new MessageMemoryRepository();
+    deploymentRepository = new MemoryRepository<Deployment>();
     messageExecutor = new MessageExecutor(wallet, messageValidator, messageRepository, onTransactionMined);
-    executionWorker = new ExecutionWorker([messageExecutor], queueMemoryStore);
+    deploymentExecutor = new DeploymentExecutor(deploymentRepository);
+    executionWorker = new ExecutionWorker([messageExecutor, deploymentExecutor], queueMemoryStore);
     signedMessage = getTestSignedMessage();
     messageHash = calculateMessageHash(signedMessage);
     await messageRepository.add(
@@ -66,7 +74,7 @@ describe('UNIT: Queue Service', async () => {
 
   it('should throw error when hash is null', async () => {
     messageExecutor.execute = sinon.fake.returns(null);
-    executionWorker = new ExecutionWorker([messageExecutor], queueMemoryStore);
+    executionWorker = new ExecutionWorker([messageExecutor, deploymentExecutor], queueMemoryStore);
     executionWorker.start();
     const markAsErrorSpy = sinon.spy(messageRepository.markAsError);
     messageRepository.markAsError = markAsErrorSpy;
@@ -82,7 +90,7 @@ describe('UNIT: Queue Service', async () => {
   it('should not execute if the executor cannot execute, but remove from the queue', async () => {
     messageExecutor.canExecute = sinon.fake.returns(false);
     const executeSpy = sinon.spy(messageExecutor, 'execute');
-    executionWorker = new ExecutionWorker([messageExecutor], queueMemoryStore);
+    executionWorker = new ExecutionWorker([messageExecutor, deploymentExecutor], queueMemoryStore);
     executionWorker.start();
     queueMemoryStore.remove = sinon.spy(queueMemoryStore.remove);
     await messageRepository.add(messageHash, createMessageItem(signedMessage));


### PR DESCRIPTION
- Introduce `DeploymentExecutor` and add it to the list in `ExecutionWorker`
- It marks the `Deployment` as pending/error/success in the repository, analogical to `MessageExecutor`:
https://github.com/UniversalLogin/UniversalLoginSDK/blob/f99750319cc2a7188bc469fcfb546217d0acc454/universal-login-relayer/lib/integration/ethereum/MessageExecutor.ts#L25-L39

- It does not perform the actual execution (yet)