### PR TITLE
React: Swap USD and ETH in GasPrice

### DIFF
--- a/universal-login-react/src/ui/commons/GasPrice/SelectedGasPrice.tsx
+++ b/universal-login-react/src/ui/commons/GasPrice/SelectedGasPrice.tsx
@@ -17,8 +17,8 @@ export const SelectedGasPrice = ({modeName, gasLimit, gasOption, usdAmount, onCl
         <div className="transaction-fee-details">
           <img src="" alt="" className="transaction-fee-item-icon" />
           <div>
-            <p className="transaction-fee-amount">{safeMultiply(gasOption.gasPrice, gasLimit)} {gasOption.token.symbol}</p>
             <p className="transaction-fee-amount-usd">{safeMultiply(utils.parseEther(usdAmount.toString()), gasLimit)} USD</p>
+            <p className="transaction-fee-amount">{safeMultiply(gasOption.gasPrice, gasLimit)} {gasOption.token.symbol}</p>
           </div>
         </div>
       </div>

--- a/universal-login-react/src/ui/commons/GasPrice/TransactionFeeChoose.tsx
+++ b/universal-login-react/src/ui/commons/GasPrice/TransactionFeeChoose.tsx
@@ -39,8 +39,8 @@ export const TransactionFeeChoose = ({gasModes, gasLimit, onGasOptionChanged, mo
                 <div className="transaction-fee-details">
                   <img src="" alt="" className="transaction-fee-item-icon" />
                   <div>
-                    <p className="transaction-fee-amount">{safeMultiply(option.gasPrice, gasLimit)} {option.token.symbol}</p>
                     <p className="transaction-fee-amount-usd">{safeMultiply(utils.parseEther(usdAmount.toString()), gasLimit)} USD</p>
+                    <p className="transaction-fee-amount">{safeMultiply(option.gasPrice, gasLimit)} {option.token.symbol}</p>
                   </div>
                 </div>
                 {renderBalance(option)}

--- a/universal-login-react/src/ui/styles/gasPrice.sass
+++ b/universal-login-react/src/ui/styles/gasPrice.sass
@@ -153,13 +153,13 @@
     display: flex
     align-items: center
 
-  .transaction-fee-amount
+  .transaction-fee-amount-usd
     margin: 0
     font-weight: 600
     font-size: 12px
     line-height: 18px
 
-  .transaction-fee-amount-usd
+  .transaction-fee-amount
     margin: 0
     font-size: 10px
     line-height: 15px

--- a/universal-login-wallet/src/ui/styles/components/_gas-price.sass
+++ b/universal-login-wallet/src/ui/styles/components/_gas-price.sass
@@ -13,11 +13,11 @@
       border-color: #C7C7D4
       background: #fff
 
-    .transaction-fee-amount
+    .transaction-fee-amount-usd
       font-weight: 700
       color: #31405E
 
-    .transaction-fee-amount-usd
+    .transaction-fee-amount
       color: #31405E
 
     .gas-price-selected-divider


### PR DESCRIPTION
# Summary
In GasPrice make USD be more visible and ETH less visible and on the bottom. 

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

