### PR TITLE
React: Change default text in ExplorerLink

### DIFF
--- a/universal-login-react/src/ui/commons/ExplorerLink.tsx
+++ b/universal-login-react/src/ui/commons/ExplorerLink.tsx
@@ -10,6 +10,6 @@ export const ExplorerLink = ({chainName, transactionHash}: ExplorerLinkProps) =>
   <p className="txn-hash-text">
     {transactionHash
       ? <a className="txn-hash-link" href={getEtherscanUrl(chainName, transactionHash!)} target="_blank">{transactionHash}</a>
-      : 'The transaction will start in a moment'}
+      : 'The transaction hash will show in a moment'}
   </p>
 );


### PR DESCRIPTION
# Summary
Change default text in ExplorerLink which is shown when a transaction hash doesn't exist.

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes

