### PR TITLE
Return waitToBeSuccess and waitForTransactionHash in generateBackupCodes

### DIFF
--- a/universal-login-react/src/ui/BackupCodes/BackupCodes.tsx
+++ b/universal-login-react/src/ui/BackupCodes/BackupCodes.tsx
@@ -21,8 +21,8 @@ export const BackupCodes = ({deployedWallet, className}: BackupProps) => {
   const generateBackupCodes = async () => {
     setState('Loading');
     try {
-      const {codes, execution} = await deployedWallet.generateBackupCodes();
-      await execution.waitToBeSuccess();
+      const {waitToBeSuccess} = await deployedWallet.generateBackupCodes();
+      const codes = await waitToBeSuccess();
       setBackupCodes(codes.concat(backupCodes));
       setState('Generated');
     } catch (e) {

--- a/universal-login-react/src/ui/BackupCodes/BackupCodes.tsx
+++ b/universal-login-react/src/ui/BackupCodes/BackupCodes.tsx
@@ -21,7 +21,8 @@ export const BackupCodes = ({deployedWallet, className}: BackupProps) => {
   const generateBackupCodes = async () => {
     setState('Loading');
     try {
-      const codes = await deployedWallet.generateBackupCodes();
+      const {codes, execution} = await deployedWallet.generateBackupCodes();
+      await execution.waitToBeSuccess();
       setBackupCodes(codes.concat(backupCodes));
       setState('Generated');
     } catch (e) {

--- a/universal-login-sdk/lib/api/DeployedWallet.ts
+++ b/universal-login-sdk/lib/api/DeployedWallet.ts
@@ -108,10 +108,10 @@ export class DeployedWallet implements ApplicationWallet {
     const execution = await this.sdk.addKeys(this.contractAddress, addresses, this.privateKey, {gasToken: ETHER_NATIVE_TOKEN.address, gasPrice: DEFAULT_GAS_PRICE, gasLimit: DEFAULT_GAS_LIMIT});
     return {
       waitToBeSuccess: async () => {
-        await execution.waitToBeSuccess()
+        await execution.waitToBeSuccess();
         return codes;
       },
-      waitForTransactionHash: execution.waitForTransactionHash
+      waitForTransactionHash: execution.waitForTransactionHash,
     };
   }
 

--- a/universal-login-sdk/lib/api/DeployedWallet.ts
+++ b/universal-login-sdk/lib/api/DeployedWallet.ts
@@ -15,6 +15,11 @@ import WalletContract from '@universal-login/contracts/build/Wallet.json';
 import {BigNumber} from 'ethers/utils';
 import {OnBalanceChange} from '../core/observers/BalanceObserver';
 
+interface BackupCodesWithExecution {
+  codes: string[];
+  execution: Execution;
+}
+
 export class DeployedWallet implements ApplicationWallet {
   constructor(
     public readonly contractAddress: string,
@@ -89,7 +94,7 @@ export class DeployedWallet implements ApplicationWallet {
     return this.sdk.getGasModes();
   }
 
-  async generateBackupCodes(): Promise<string[]> {
+  async generateBackupCodes(): Promise<BackupCodesWithExecution> {
     const codes: string[] = [generateBackupCode(), generateBackupCode()];
     const addresses: string[] = [];
 
@@ -99,8 +104,7 @@ export class DeployedWallet implements ApplicationWallet {
     }
 
     const execution = await this.sdk.addKeys(this.contractAddress, addresses, this.privateKey, {gasToken: ETHER_NATIVE_TOKEN.address, gasPrice: DEFAULT_GAS_PRICE, gasLimit: DEFAULT_GAS_LIMIT});
-    await execution.waitToBeSuccess();
-    return codes;
+    return {codes, execution};
   }
 
   signMessage(bytes: Uint8Array) {

--- a/universal-login-sdk/lib/api/DeployedWallet.ts
+++ b/universal-login-sdk/lib/api/DeployedWallet.ts
@@ -19,7 +19,6 @@ import {OnBalanceChange} from '../core/observers/BalanceObserver';
 interface BackupCodesWithExecution {
   waitToBeSuccess: () => Promise<string[]>;
   waitForTransactionHash: () => Promise<MessageStatus>;
-
 }
 
 export class DeployedWallet implements ApplicationWallet {

--- a/universal-login-sdk/test/e2e/DeployedWallet.ts
+++ b/universal-login-sdk/test/e2e/DeployedWallet.ts
@@ -50,9 +50,12 @@ describe('E2E: DeployedWallet', async () => {
     });
   });
 
-  describe('generateBackupCode', () => {
+  describe('generateBackupCodes', () => {
     it('returns the code and update contract keys', async () => {
-      const codes = await deployedWallet.generateBackupCodes();
+      const {codes, execution} = await deployedWallet.generateBackupCodes();
+      const {transactionHash} = await execution.waitForTransactionHash();
+      expect(transactionHash).to.be.properHex;
+      await execution.waitToBeSuccess();
       const {address} = await walletFromBrain(ensName, codes[0]);
       expect(await walletContract.keyExist(address)).to.be.true;
       const connectedDevices = await deployedWallet.getConnectedDevices();

--- a/universal-login-sdk/test/e2e/DeployedWallet.ts
+++ b/universal-login-sdk/test/e2e/DeployedWallet.ts
@@ -55,7 +55,7 @@ describe('E2E: DeployedWallet', async () => {
       const {waitToBeSuccess, waitForTransactionHash} = await deployedWallet.generateBackupCodes();
       const {transactionHash} = await waitForTransactionHash();
       expect(transactionHash).to.be.properHex;
-      const codes = await waitToBeSuccess()
+      const codes = await waitToBeSuccess();
       const {address} = await walletFromBrain(ensName, codes[0]);
       expect(await walletContract.keyExist(address)).to.be.true;
       const connectedDevices = await deployedWallet.getConnectedDevices();

--- a/universal-login-sdk/test/e2e/DeployedWallet.ts
+++ b/universal-login-sdk/test/e2e/DeployedWallet.ts
@@ -52,10 +52,10 @@ describe('E2E: DeployedWallet', async () => {
 
   describe('generateBackupCodes', () => {
     it('returns the code and update contract keys', async () => {
-      const {codes, execution} = await deployedWallet.generateBackupCodes();
-      const {transactionHash} = await execution.waitForTransactionHash();
+      const {waitToBeSuccess, waitForTransactionHash} = await deployedWallet.generateBackupCodes();
+      const {transactionHash} = await waitForTransactionHash();
       expect(transactionHash).to.be.properHex;
-      await execution.waitToBeSuccess();
+      const codes = await waitToBeSuccess()
       const {address} = await walletFromBrain(ensName, codes[0]);
       expect(await walletContract.keyExist(address)).to.be.true;
       const connectedDevices = await deployedWallet.getConnectedDevices();


### PR DESCRIPTION
# Summary
Return execution and codes in generateBackupCodes to be able to use waitForTransactionHash in React

Fixes: 0

## Checklist
- [x] Change is small and easy to review (please split big changes into multiple PRs)
- [x] Change is consistent with architecture
- [x] Change is consistent with test architecture
- [x] Change is consistent with naming conventions
- [x] New code is covered with tests
- [x] Tests related to old code are updated
- [x] Documentation is up to date with changes
