### PR TITLE
Merglify - dont merge WIP PRs

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=2"
       - base=master
+      - label!=WIP
     actions:
       merge:
         strict: smart


### PR DESCRIPTION
If there are approvals and everything, and for some reason you want to keep the merglify from merging the PR, there should be an option to prevent it. Just add a WIP label then.