### PR TITLE
Generate just one backup code

### DIFF
--- a/universal-login-react/src/ui/BackupCodes/BackupCodes.tsx
+++ b/universal-login-react/src/ui/BackupCodes/BackupCodes.tsx
@@ -40,9 +40,9 @@ export const BackupCodes = ({deployedWallet, className}: BackupProps) => {
       );
     case 'InProgress':
       return (<>
-        <Prompt message="Are you sure you want to leave? The backup codes are being generated." />
+        <Prompt message="Are you sure you want to leave? The backup code is being generated." />
         <WaitingForTransaction
-          action='Generating backup codes'
+          action='Generating backup code'
           relayerConfig={relayerConfig}
           className={className}
           transactionHash={state.transactionHash}
@@ -51,7 +51,7 @@ export const BackupCodes = ({deployedWallet, className}: BackupProps) => {
     case 'Generated':
       return (
         <>
-          <Prompt message="Are you sure you want to leave? The backup codes will not be displayed again." />
+          <Prompt message="Are you sure you want to leave? The backup code will not be displayed again." />
           <BackupCodesView
             codes={state.codes}
             printCodes={window.print}

--- a/universal-login-react/test/ui/BackupCodes.test.tsx
+++ b/universal-login-react/test/ui/BackupCodes.test.tsx
@@ -33,7 +33,7 @@ describe('INT: BackupCodes', () => {
     });
     dashboard.backupCodes().clickGenerate();
     await waitExpect(
-      () => expect(dashboard.backupCodes().getBackupCodes().length).to.be.eq(2),
+      () => expect(dashboard.backupCodes().getBackupCodes().length).to.be.eq(1),
       13000,
     );
   }).timeout(15000);

--- a/universal-login-sdk/src/api/wallet/DeployedWallet.ts
+++ b/universal-login-sdk/src/api/wallet/DeployedWallet.ts
@@ -106,7 +106,7 @@ export class DeployedWallet extends AbstractWallet {
   }
 
   async generateBackupCodes(executionOptions: ExecutionOptions): Promise<BackupCodesWithExecution> {
-    const codes: string[] = [generateBackupCode(), generateBackupCode()];
+    const codes: string[] = [generateBackupCode()];
     const addresses: string[] = [];
 
     for (const code of codes) {

--- a/universal-login-sdk/src/api/wallet/DeployedWallet.ts
+++ b/universal-login-sdk/src/api/wallet/DeployedWallet.ts
@@ -114,7 +114,7 @@ export class DeployedWallet extends AbstractWallet {
       addresses.push(address);
     }
 
-    const execution = await this.addKeys(addresses, {gasLimit: DEFAULT_GAS_LIMIT, ...executionOptions});
+    const execution = await this.addKey(addresses[0], {gasLimit: DEFAULT_GAS_LIMIT, ...executionOptions});
     return new BackupCodesWithExecution(execution, codes);
   }
 

--- a/universal-login-sdk/test/api/wallet/DeployedWallet.int.test.ts
+++ b/universal-login-sdk/test/api/wallet/DeployedWallet.int.test.ts
@@ -56,6 +56,7 @@ describe('INT: DeployedWallet', async () => {
     const {transactionHash} = await waitForTransactionHash();
     expect(transactionHash).to.be.properHex;
     const codes = await waitToBeSuccess();
+    expect(codes.length).to.eq(1);
     const {address} = await walletFromBrain(ensName, codes[0]);
     expect(await walletContract.keyExist(address)).to.be.true;
     const connectedDevices = await deployedWallet.getConnectedDevices();


### PR DESCRIPTION
I didn't change the interface of backup codes services (BackupCodesService or BackupCodesWithExecution). `codes` is still an array of codes, but now it has only one code. Additionally, `generateBackupCodes` function uses `addKey` function instead of using `addKeys` function that will not work with GnosisSafe. 