### PR TITLE
Update enignes verisons

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish:packages": "yarn lerna publish from-package"
   },
   "engines": {
-    "node": "^8.10.0 || ^10.13.0 || >=11.10.1",
+    "node": "^10.13.0 || ^11.10.1",
     "yarn": ">=1.9.4"
   }
 }

--- a/universal-login-relayer/package.json
+++ b/universal-login-relayer/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf dist"
   },
   "engines": {
-    "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+    "node": "^10.13.0 || ^11.10.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
* ^8.10.0 removed because waffle requres >=10
* \>=11.10.1 changes to ^11.10.1 because sha3 incompatible wit >=12 versions of node